### PR TITLE
Flatpak version is now possible & fixed icon filename

### DIFF
--- a/lib/xdg/ayugram.desktop.desktop
+++ b/lib/xdg/ayugram.desktop.desktop
@@ -3,7 +3,7 @@ Name=AyuGram Desktop
 Comment=Desktop version of AyuGram - ToS breaking Telegram client
 TryExec=ayugram-desktop
 Exec=DESKTOPINTEGRATION=1 ayugram-desktop -- %u
-Icon=telegram
+Icon=ayugram
 Terminal=false
 StartupWMClass=AyuGram
 Type=Application

--- a/lib/xdg/io.github.ayugram_desktop.desktop
+++ b/lib/xdg/io.github.ayugram_desktop.desktop
@@ -1,0 +1,22 @@
+[Desktop Entry]
+Name=AyuGram Desktop
+Comment=Desktop version of AyuGram - ToS breaking Telegram client
+TryExec=ayugram-desktop
+Exec=DESKTOPINTEGRATION=1 ayugram-desktop -- %u
+Icon=ayugram
+Terminal=false
+StartupWMClass=AyuGram
+Type=Application
+Categories=Chat;Network;InstantMessaging;Qt;
+MimeType=x-scheme-handler/tg;
+Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;
+Actions=quit;
+DBusActivatable=true
+SingleMainWindow=true
+X-GNOME-UsesNotifications=true
+X-GNOME-SingleWindow=true
+
+[Desktop Action quit]
+Exec=ayugram-desktop -quit
+Name=Quit AyuGram
+Icon=application-exit

--- a/lib/xdg/io.github.ayugram_desktop.metainfo.xml
+++ b/lib/xdg/io.github.ayugram_desktop.metainfo.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop">
+    <id>ayugram.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0</project_license>
+    <name>AyuGram Desktop</name>
+    <summary>Desktop version of AyuGram - ToS breaking Telegram client</summary>
+    <description>
+        <p>Telegram Desktop with Ghost Mode, Anti-Recall and cool design.</p>
+    </description>
+    <categories>
+        <category>Network</category>
+        <category>InstantMessaging</category>
+    </categories>
+    <update_contact>helpdesk_at_radolyn.com</update_contact>
+    <developer_name>Radolyn Labs</developer_name>
+    <url type="homepage">https://ayugram.one/</url>
+    <url type="bugtracker">https://t.me/ayugramchat/1262</url>
+    <url type="translate">https://crowdin.com/project/ayugram</url>
+    <url type="contribute">https://github.com/AyuGram/AyuGramDesktop/blob/dev/.github/CONTRIBUTING.md</url>
+    <screenshots>
+      <screenshot type="default">
+        <image>https://raw.githubusercontent.com/telegramdesktop/tdesktop/dev/docs/assets/preview.png</image>
+      </screenshot>
+    </screenshots>
+    <keywords>
+        <keyword>tg</keyword>
+        <keyword>telegram</keyword>
+        <keyword>tdesktop</keyword>
+        <keyword>messaging</keyword>
+        <keyword>messenger</keyword>
+        <keyword>chat</keyword>
+        <keyword>sms</keyword>
+        <keyword>im</keyword>
+        <keyword>ayugram</keyword>
+    </keywords>
+    <requires>
+        <display_length compare="ge">medium</display_length>
+        <internet>always</internet>
+    </requires>
+    <supports>
+        <control>pointing</control>
+        <control>keyboard</control>
+        <control>touch</control>
+    </supports>
+    <content_rating type="oars-1.1">
+        <content_attribute id="violence-cartoon">none</content_attribute>
+        <content_attribute id="violence-fantasy">none</content_attribute>
+        <content_attribute id="violence-realistic">none</content_attribute>
+        <content_attribute id="violence-bloodshed">none</content_attribute>
+        <content_attribute id="violence-sexual">none</content_attribute>
+        <content_attribute id="violence-desecration">none</content_attribute>
+        <content_attribute id="violence-slavery">none</content_attribute>
+        <content_attribute id="violence-worship">none</content_attribute>
+        <content_attribute id="drugs-alcohol">none</content_attribute>
+        <content_attribute id="drugs-narcotics">none</content_attribute>
+        <content_attribute id="drugs-tobacco">none</content_attribute>
+        <content_attribute id="sex-nudity">none</content_attribute>
+        <content_attribute id="sex-themes">none</content_attribute>
+        <content_attribute id="sex-homosexuality">none</content_attribute>
+        <content_attribute id="sex-prostitution">none</content_attribute>
+        <content_attribute id="sex-adultery">none</content_attribute>
+        <content_attribute id="sex-appearance">none</content_attribute>
+        <content_attribute id="language-profanity">none</content_attribute>
+        <content_attribute id="language-humor">none</content_attribute>
+        <content_attribute id="language-discrimination">none</content_attribute>
+        <content_attribute id="social-chat">intense</content_attribute>
+        <content_attribute id="social-info">none</content_attribute>
+        <content_attribute id="social-audio">intense</content_attribute>
+        <content_attribute id="social-location">none</content_attribute>
+        <content_attribute id="social-contacts">intense</content_attribute>
+        <content_attribute id="money-purchasing">intense</content_attribute>
+        <content_attribute id="money-gambling">none</content_attribute>
+        <content_attribute id="money-advertising">moderate</content_attribute>
+    </content_rating>
+    <launchable type="desktop-id">ayugram.desktop.desktop</launchable>
+    <provides>
+        <binary>ayugram-desktop</binary>
+    </provides>
+</component>

--- a/lib/xdg/io.github.ayugram_desktop.service
+++ b/lib/xdg/io.github.ayugram_desktop.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=ayugram.desktop
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/ayugram-desktop


### PR DESCRIPTION
This pull request fixes following issues:
- If building AyuGram from GitHub repository, ayugram.desktop.desktop file from lib/xdg is used by default where "Icon" equals "telegram" and not "ayugram"
- Make flatpak install successfully. Currently encountering issues where desktop, metainfo and service filenames doesn't equal [my manifest](https://git.killarious.org/ayugram-releases/flatpak) app id:
```
Rewriting contents of io.github.ayugram_desktop.desktop
Error: Can't load desktop file /home/prizrak282/flatpak/.flatpak-builder/rofiles/rofiles-5NJQFG/files/share/applications/io.github.ayugram_desktop.desktop: Error opening file /home/prizrak282/flatpak/.flatpak-builder/rofiles/rofiles-5NJQFG/files/share/applications/io.github.ayugram_desktop.desktop: No such file or directory
```
64gram has the following layout:
![Screenshot_20231030-183449_Fennec](https://github.com/AyuGram/AyuGramDesktop/assets/81514356/35c76bea-3f91-464e-9dc1-e2cc16b15058)
Where filenames are equal to Flathub manifest name