### PR TITLE
fix: Use correct executable path

### DIFF
--- a/lib/xdg/com.ayugram.desktop.service
+++ b/lib/xdg/com.ayugram.desktop.service
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=com.ayugram.desktop
-Exec=@CMAKE_INSTALL_FULL_BINDIR@/com.ayugram.desktop
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/ayugram-desktop


### PR DESCRIPTION
This file was added by https://github.com/AyuGram/AyuGramDesktop/pull/10, but it did not use correct executable name. After installing, the executable name is `ayugram-desktop`, which will result that AyuGramDesktop cannot be activated by DBus on Linux.