### PR TITLE
Fix for application menu entry on GNOME

### DIFF
--- a/lib/xdg/com.ayugram.desktop.desktop
+++ b/lib/xdg/com.ayugram.desktop.desktop
@@ -2,7 +2,7 @@
 Name=AyuGram Desktop
 Comment=Desktop version of AyuGram - ToS breaking Telegram client
 TryExec=ayugram-desktop
-Exec=DESKTOPINTEGRATION=1 ayugram-desktop -- %u
+Exec=env DESKTOPINTEGRATION=1 ayugram-desktop -- %u
 Icon=ayugram
 Terminal=false
 StartupWMClass=AyuGram


### PR DESCRIPTION
Without this change the desktop entry doesn't appear on gnome.
This is because of the environment variable.
After applying the change and running `sudo update-desktop-database` the entry appears.