### PR TITLE
Fix shot's crop on macos

### DIFF
--- a/Telegram/SourceFiles/ayu/features/messageshot/message_shot.cpp
+++ b/Telegram/SourceFiles/ayu/features/messageshot/message_shot.cpp
@@ -353,6 +353,7 @@ QImage Make(not_null<QWidget*> box, const ShotConfig &config) {
 	}
 
 	height *= style::DevicePixelRatio();
+        width *= style::DevicePixelRatio();
 
 	// create the image
 	QImage image(width, height, QImage::Format_ARGB32_Premultiplied);


### PR DESCRIPTION
This will fix cropping of image in SHOT on MacOs