### PR TITLE
Fix image order issues when click Download selected

### DIFF
--- a/Telegram/SourceFiles/menu/menu_item_download_files.cpp
+++ b/Telegram/SourceFiles/menu/menu_item_download_files.cpp
@@ -226,6 +226,12 @@ void AddDownloadFilesAction(
 			return;
 		}
 	}
+       std::sort(docs.begin(), docs.end(), [](const auto &a, const auto &b) {
+               return a.second < b.second;
+       });
+       std::sort(photos.begin(), photos.end(), [](const auto &a, const auto &b) {
+               return a.second < b.second;
+       });
 	const auto done = [weak = Ui::MakeWeak(list)] {
 		if (const auto strong = weak.data()) {
 			strong->cancelSelection();
@@ -249,6 +255,12 @@ void AddDownloadFilesAction(
 			return;
 		}
 	}
+       std::sort(docs.begin(), docs.end(), [](const auto &a, const auto &b) {
+               return a.second < b.second;
+       });
+       std::sort(photos.begin(), photos.end(), [](const auto &a, const auto &b) {
+               return a.second < b.second;
+       });
 	const auto done = [weak = Ui::MakeWeak(list)] {
 		if (const auto strong = weak.data()) {
 			strong->clearSelected();


### PR DESCRIPTION
This fix for this bug:
https://github.com/telegramdesktop/tdesktop/issues/25700#issuecomment-1374902558
https://github.com/telegramdesktop/tdesktop/issues/25700#issuecomment-2994087781

Photos are now sorted by message ID to ensure the correct file order when saved.
