### PR TITLE
The "Hide" context menu action now hides every media item in an album instead of only the first one

### DIFF
--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -206,7 +206,7 @@ void AddHideMessageAction(not_null<Ui::PopupMenu*> menu, HistoryItem *item) {
 		return;
 	}
 
-        const auto history = item->history();
+	const auto history = item->history();
 	const auto owner = &history->owner();
 	menu->addAction(
 		tr::ayu_ContextHideMessage(tr::now),

--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -206,15 +206,20 @@ void AddHideMessageAction(not_null<Ui::PopupMenu*> menu, HistoryItem *item) {
 		return;
 	}
 
-	const auto history = item->history();
+        const auto history = item->history();
+	const auto owner = &history->owner();
 	menu->addAction(
 		tr::ayu_ContextHideMessage(tr::now),
 		[=]()
 		{
-			item->destroy();
+			const auto ids = owner->itemOrItsGroup(item);
+			for (const auto &fullId : ids) {
+				if (const auto current = owner->message(fullId)) {
+					current->destroy();
+					AyuState::hide(current);
+				}
+			}
 			history->requestChatListMessage();
-
-			AyuState::hide(item);
 		},
 		&st::menuIconClear);
 }


### PR DESCRIPTION
The Hide feature now hides the whole album in its entirety. In `AddHideMessageAction`, the group's messages are retrieved via `owner->itemOrItsGroup(item)`, then each message is hidden. After that, the chat history is updated.


https://github.com/user-attachments/assets/3c1e7322-bc53-4c02-b760-b685a8802eeb

