### PR TITLE
Add shadow-banning channels possible (Issue 215)

### DIFF
--- a/Telegram/SourceFiles/ayu/features/filters/filters_controller.cpp
+++ b/Telegram/SourceFiles/ayu/features/filters/filters_controller.cpp
@@ -115,7 +115,8 @@ bool isBlocked(const not_null<HistoryItem*> item) {
 
 	return settings.filtersEnabled &&
 	(
-		(item->from()->isUser() && ShadowBanUtils::isShadowBanned(getDialogIdFromPeer(item->from()))) ||
+		(item->from()->isUser() &&  ShadowBanUtils::isShadowBanned(getDialogIdFromPeer(item->from()))) || 
+		(item->from()->isChannel() && ShadowBanUtils::isShadowBanned(getDialogIdFromPeer(item->from()))) ||
 		(settings.hideFromBlocked && blocked)
 	);
 }

--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -321,7 +321,7 @@ void AddOpenChannelAction(PeerData *peerData,
 void AddShadowBanAction(PeerData *peerData,
 						const Window::PeerMenuCallback &addCallback) {
 	const auto &settings = AyuSettings::getInstance();
-	if (!peerData || !peerData->isUser() || !settings.filtersEnabled) {
+	if (!peerData || !peerData->isUser() || !peerData->isChannel() || !settings.filtersEnabled) {
 		return;
 	}
 


### PR DESCRIPTION
Right now, you can shadowban/block a person to hide their messages in chats.
Yet, if a person that's blocked texts something in a chat - you'll see their messages.

This PR makes it possible to shadowban channels, and make their messages hidden. 