### PR TITLE
feat: option to hide premium emoji in chat list

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -7801,6 +7801,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "ayu_DisableAds" = "Disable Ads";
 "ayu_DisableStories" = "Disable Stories";
 "ayu_DisableCustomBackgrounds" = "Disable Custom Backgrounds";
+"ayu_HidePremiumStatuses" = "Hide Premium Statuses";
 "ayu_SmoothScroll" = "Smooth Scroll";
 "ayu_DisableNotificationsDelay" = "Disable Notify Delay";
 "ayu_LocalPremium" = "Local Telegram Premium";

--- a/Telegram/SourceFiles/ayu/ayu_settings.cpp
+++ b/Telegram/SourceFiles/ayu/ayu_settings.cpp
@@ -542,6 +542,12 @@ void AyuSettings::setDisableCustomBackgrounds(bool val) {
 	save();
 }
 
+void AyuSettings::setHidePremiumStatuses(bool val) {
+	if (_hidePremiumStatuses.current() == val) return;
+	_hidePremiumStatuses = val;
+	save();
+}
+
 void AyuSettings::setShowOnlyAddedEmojisAndStickers(bool val) {
 	if (_showOnlyAddedEmojisAndStickers.current() == val) return;
 	_showOnlyAddedEmojisAndStickers = val;

--- a/Telegram/SourceFiles/ayu/ayu_settings.h
+++ b/Telegram/SourceFiles/ayu/ayu_settings.h
@@ -251,6 +251,7 @@ public:
 	[[nodiscard]] bool disableAds() const { return _disableAds.current(); }
 	[[nodiscard]] bool disableStories() const { return _disableStories.current(); }
 	[[nodiscard]] bool disableCustomBackgrounds() const { return _disableCustomBackgrounds.current(); }
+	[[nodiscard]] bool hidePremiumStatuses() const { return _hidePremiumStatuses.current(); }
 	[[nodiscard]] bool showOnlyAddedEmojisAndStickers() const { return _showOnlyAddedEmojisAndStickers.current(); }
 	[[nodiscard]] bool collapseSimilarChannels() const { return _collapseSimilarChannels.current(); }
 	[[nodiscard]] bool hideSimilarChannels() const { return _hideSimilarChannels.current(); }
@@ -330,6 +331,7 @@ public:
 	void setDisableAds(bool val);
 	void setDisableStories(bool val);
 	void setDisableCustomBackgrounds(bool val);
+	void setHidePremiumStatuses(bool val);
 	void setShowOnlyAddedEmojisAndStickers(bool val);
 	void setCollapseSimilarChannels(bool val);
 	void setHideSimilarChannels(bool val);
@@ -421,6 +423,8 @@ public:
 	[[nodiscard]] rpl::producer<bool> disableStoriesChanges() const { return _disableStories.changes(); }
 	[[nodiscard]] rpl::producer<bool> disableCustomBackgroundsValue() const { return _disableCustomBackgrounds.value(); }
 	[[nodiscard]] rpl::producer<bool> disableCustomBackgroundsChanges() const { return _disableCustomBackgrounds.changes(); }
+	[[nodiscard]] rpl::producer<bool> hidePremiumStatusesValue() const { return _hidePremiumStatuses.value(); }
+	[[nodiscard]] rpl::producer<bool> hidePremiumStatusesChanges() const { return _hidePremiumStatuses.changes(); }
 	[[nodiscard]] rpl::producer<bool> showOnlyAddedEmojisAndStickersValue() const { return _showOnlyAddedEmojisAndStickers.value(); }
 	[[nodiscard]] rpl::producer<bool> showOnlyAddedEmojisAndStickersChanges() const { return _showOnlyAddedEmojisAndStickers.changes(); }
 	[[nodiscard]] rpl::producer<bool> collapseSimilarChannelsValue() const { return _collapseSimilarChannels.value(); }
@@ -626,6 +630,7 @@ private:
 	rpl::variable<bool> _showStreamerToggleInDrawer = false;
 	rpl::variable<bool> _showGhostToggleInTray = true;
 	rpl::variable<bool> _showStreamerToggleInTray = false;
+	rpl::variable<bool> _hidePremiumStatuses = false;
 	rpl::variable<QString> _monoFont;
 	rpl::variable<bool> _hideNotificationCounters = false;
 	rpl::variable<bool> _hideNotificationBadge = false;

--- a/Telegram/SourceFiles/ayu/ui/settings/settings_appearance.cpp
+++ b/Telegram/SourceFiles/ayu/ui/settings/settings_appearance.cpp
@@ -213,6 +213,13 @@ void BuildAppearance(SectionBuilder &builder, AyuSectionBuilder &ayu) {
 		.setter = &AyuSettings::setDisableCustomBackgrounds,
 	});
 
+	ayu.addSettingToggle({
+		.id = u"ayu/hidePremiumStatuses"_q,
+		.title = tr::ayu_HidePremiumStatuses(),
+		.getter = &AyuSettings::hidePremiumStatuses,
+		.setter = &AyuSettings::setHidePremiumStatuses,
+	});
+
 	const auto controller = builder.controller();
 	builder.addButton({
 		.id = u"ayu/monoFont"_q,

--- a/Telegram/SourceFiles/history/view/history_view_message.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_message.cpp
@@ -1684,7 +1684,9 @@ void Message::paintFromName(
 		}
 		return &info->nameText();
 	}();
-	const auto statusWidth = _fromNameStatus
+	const auto &settings = AyuSettings::getInstance();
+	const auto hidePremiumStatuses = settings.hidePremiumStatuses();
+	const auto statusWidth = _fromNameStatus && !hidePremiumStatuses
 		? st::dialogsPremiumIcon.icon.width()
 		: 0;
 	if (statusWidth && availableWidth > statusWidth) {
@@ -1733,7 +1735,7 @@ void Message::paintFromName(
 		.elisionLines = 1,
 	});
 	const auto skipWidth = nameText->maxWidth()
-		+ (_fromNameStatus
+		+ (_fromNameStatus && !hidePremiumStatuses
 			? (st::dialogsPremiumIcon.icon.width()
 				+ st::msgServiceFont->spacew)
 			: 0)

--- a/Telegram/SourceFiles/ui/unread_badge.cpp
+++ b/Telegram/SourceFiles/ui/unread_badge.cpp
@@ -21,6 +21,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_dialogs.h"
 
 // AyuGram includes
+#include "ayu/ayu_settings.h"
 #include "ayu/utils/telegram_helpers.h"
 #include "styles/style_info.h"
 
@@ -154,6 +155,9 @@ PeerBadge::~PeerBadge() = default;
 int PeerBadge::drawGetWidth(Painter &p, Descriptor &&descriptor) {
 	Expects(descriptor.customEmojiRepaint != nullptr);
 
+	const auto &settings = AyuSettings::getInstance();
+	const auto hidePremiumStatuses = settings.hidePremiumStatuses();
+
 	const auto peer = descriptor.peer;
 	if ((descriptor.scam && (peer->isScam() || peer->isFake()))
 		|| (descriptor.direct && peer->isMonoforum())) {
@@ -174,8 +178,10 @@ int PeerBadge::drawGetWidth(Painter &p, Descriptor &&descriptor) {
 			|| descriptor.bothVerifyAndStatus
 			|| !emojiStatus);
 	const auto paintEmoji = emojiStatus
-		&& (!paintVerify || descriptor.bothVerifyAndStatus);
-	const auto paintStar = premiumStar && !paintVerify;
+		&& (!paintVerify || descriptor.bothVerifyAndStatus)
+		&& !hidePremiumStatuses;
+	const auto paintStar = premiumStar && !paintVerify
+		&& !hidePremiumStatuses;
 
 	const auto paintExteraCustom =
 		isCustomBadgePeer(getBareID(peer));


### PR DESCRIPTION
This option allows to hide premium emoji status, premium star and channel status from chat list and chat header near peer name.