### PR TITLE
Disable vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ project(Telegram
     HOMEPAGE_URL "https://ayugram.one"
 )
 
+if (WIN32 AND MSVC)
+    set(CMAKE_VS_GLOBALS "VcpkgEnabled=false")
+endif()
+
 if (APPLE)
     enable_language(OBJC OBJCXX)
 endif()


### PR DESCRIPTION
If vcpkg is integrated in Visual Studio and OpenSSL is installed there, the build may link against it automatically.

This causes AyuGram.exe to fail at runtime with
"libcrypto-3-x64.dll not found".