### PR TITLE
fix: clear menu‑toggle ripple when popup destroyed by active‑chat change

### DIFF
--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
@@ -959,6 +959,7 @@ void TopBarWidget::setActiveChat(
 	updateUnreadBadge();
 	refreshInfoButton();
 	if (_menu) {
+		_menuToggle->setForceRippled(false);
 		_menu = nullptr;
 	}
 	updateOnlineDisplay();


### PR DESCRIPTION
When the top‑bar three dots menu is used to navigate (like "View Deleted"), `TopBarWidget::_menu` is nulled as part of the active‑chat update. The popup’s destroyed‑callback checks `weak->_menu == menu` before clearing the button’s force‑ripple state, but `_menu` has already been set to nullptr, so the comparison fails. After returning from the new section the toggle remains highlighted until another click. Fix it by explicitly clearing the ripple state.