### PR TITLE
Show official app flag in session details

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1346,7 +1346,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_sessions_terminate" = "Terminate Session";
 "lng_sessions_application" = "Application";
 "lng_sessions_system" = "System version";
-"lng_sessions_official_app" = "Official app";
 "lng_sessions_browser" = "Browser";
 "lng_sessions_ip" = "IP address";
 "lng_sessions_location" = "Location";

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -1346,6 +1346,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_sessions_terminate" = "Terminate Session";
 "lng_sessions_application" = "Application";
 "lng_sessions_system" = "System version";
+"lng_sessions_official_app" = "Official app";
 "lng_sessions_browser" = "Browser";
 "lng_sessions_ip" = "IP address";
 "lng_sessions_location" = "Location";

--- a/Telegram/SourceFiles/api/api_authorizations.cpp
+++ b/Telegram/SourceFiles/api/api_authorizations.cpp
@@ -30,6 +30,7 @@ Authorizations::Entry ParseEntry(const MTPDauthorization &data) {
 	result.hash = data.is_current() ? 0 : data.vhash().v;
 	result.incomplete = data.is_password_pending();
 	result.callsDisabled = data.is_call_requests_disabled();
+	result.officialApp = data.is_official_app();
 
 	const auto apiId = result.apiId = data.vapi_id().v;
 	const auto isTest = (apiId == TestApiId);

--- a/Telegram/SourceFiles/api/api_authorizations.h
+++ b/Telegram/SourceFiles/api/api_authorizations.h
@@ -23,6 +23,7 @@ public:
 
 		bool incomplete = false;
 		bool callsDisabled = false;
+		bool officialApp = false;
 		int apiId = 0;
 		TimeId activeTime = 0;
 		QString name, active, info, ip, location, system, platform;

--- a/Telegram/SourceFiles/settings/sections/settings_active_sessions.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_active_sessions.cpp
@@ -462,7 +462,7 @@ void SessionInfoBox(
 		st::menuIconInfo);
 	AddSessionInfoRow(
 		container,
-		tr::lng_sessions_official_app(),
+		tr::ayu_SessionInfoOfficialApp(),
 		data.officialApp ? tr::lng_box_yes(tr::now) : tr::lng_box_no(tr::now),
 		st::menuIconInfo);
 	AddSessionInfoRow(

--- a/Telegram/SourceFiles/settings/sections/settings_active_sessions.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_active_sessions.cpp
@@ -462,6 +462,11 @@ void SessionInfoBox(
 		st::menuIconInfo);
 	AddSessionInfoRow(
 		container,
+		tr::lng_sessions_official_app(),
+		data.officialApp ? tr::lng_box_yes(tr::now) : tr::lng_box_no(tr::now),
+		st::menuIconInfo);
+	AddSessionInfoRow(
+		container,
 		tr::lng_sessions_ip(),
 		data.ip,
 		st::menuIconIpAddress);


### PR DESCRIPTION
Store the server-provided `official_app` flag in the active session data model and expose it in the session details popup.

Add a localized label and render the flag as a Yes/No field so the UI can show whether Telegram marks a session as an official app.

This is how it shows an AyuGram or Official Telegram Desktop session:
<img width="263" height="193" alt="image" src="https://github.com/user-attachments/assets/e12ed152-cea9-4480-b19c-1cca4acabb71" />


This is how it shows an unofficial client, e.g. Nekogram:
<img width="221" height="199" alt="image" src="https://github.com/user-attachments/assets/04e01ca3-cbcc-4e2a-83c1-fdf98340281b" />

---

It is important to watch for this server-provided flag, because they might start marking chats with people using unofficial clients as potentially dangerous. So it is better to know in advance if some of my sessions are considered as originating from unofficial clients. This message was reportedly added in iOS translation recently:

![photo_2026-03-29_21-02-58](https://github.com/user-attachments/assets/8a41fcf9-b129-4444-9226-294f3ab49343)
