### PR TITLE
Update Homebrew installation instructions for ayugram

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -70,7 +70,8 @@ scoop install ayugram
 #### Homebrew
 
 ```bash
-brew install --cask ayugram
+brew tap SoftwareRat/unsigned-tap
+brew install --cask SoftwareRat/unsigned-tap/ayugram
 ```
 
 ### Arch Linux

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ You can download prebuilt macOS package from [Releases tab](https://github.com/A
 #### Homebrew
 
 ```bash
-brew install --cask ayugram
+brew tap SoftwareRat/unsigned-tap
+brew install --cask SoftwareRat/unsigned-tap/ayugram
 ```
 
 ### Arch Linux


### PR DESCRIPTION
This pull request updates the installation instructions for macOS in both the English (`README.md`) and Russian (`README-RU.md`) documentation. The new instructions reflect the need to add a custom tap before installing the `ayugram` package with Homebrew.

**Reason for change:**
AyuGram has been marked as deprecated in the official `Homebrew/homebrew-cask` repository with a scheduled disable date of `2026-09-01`. The official Homebrew repository enforces Gatekeeper checks, dropping applications that are unsigned or unnotarized by Apple. Routing the installation through `SoftwareRat/unsigned-tap` ensures continued availability for users. This alternative tap hosts the cask and automatically strips the quarantine attribute upon installation, ensuring the app launches normally without Gatekeeper warnings.

**Documentation updates:**
* Updated Homebrew installation steps to require tapping `SoftwareRat/unsigned-tap` before installing the `ayugram` cask in both `README.md` and `README-RU.md`.