### PR TITLE
fix: preserve PNG transparency in chat wallpapers

### DIFF
--- a/Telegram/SourceFiles/boxes/background_box.cpp
+++ b/Telegram/SourceFiles/boxes/background_box.cpp
@@ -250,7 +250,7 @@ void BackgroundBox::chooseFromFile() {
 		auto image = Images::Read({
 			.path = result.paths.isEmpty() ? QString() : result.paths.front(),
 			.content = result.remoteContent,
-			.forceOpaque = true,
+			.forceOpaque = false,
 		}).image;
 		if (image.isNull() || image.width() <= 0 || image.height() <= 0) {
 			return;

--- a/Telegram/SourceFiles/settings/sections/settings_chat.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_chat.cpp
@@ -716,7 +716,7 @@ void ChooseFromFile(
 		auto image = Images::Read({
 			.path = result.paths.isEmpty() ? QString() : result.paths.front(),
 			.content = result.remoteContent,
-			.forceOpaque = true,
+			.forceOpaque = false,
 		}).image;
 		if (image.isNull() || image.width() <= 0 || image.height() <= 0) {
 			return;


### PR DESCRIPTION
Respect the user's chosen image as-is without forcing opacity, which naturally enables transparent chat background support.

closes #361 

Upstream PR: https://github.com/telegramdesktop/tdesktop/pull/30698