### PR TITLE
docs: update Gentoo overlay link to active maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Install `ayugram-desktop` from [nixpkgs](https://search.nixos.org/packages?chann
 
 ### Gentoo Linux
 
-See [this repository](https://codeberg.org/OverLessArtem/ayugram-ebuild-gentoo) for installation manual.
+See [this repository](https://github.com/Gur0v/ayugram-overlay) for installation manual.
 
 ### Void Linux
 See [this repository](https://codeberg.org/OverLessArtem/ayugram-template-void) for installation manual.


### PR DESCRIPTION
The guy running the Codeberg Gentoo overlay listed in the README stopped updating it a while ago. To keep things moving, I really want to pick up the torch.

I forked the overlay, updated the ebuilds to v6.7.8, and even added a binary release (-bin) for people who don't want to sit through compile times. These binaries are compiled directly from upstream using a GitHub Actions workflow included right in the repository. Everything has been thoroughly tested and is production-ready.