### PR TITLE
Fix who-read submenu hover crash

### DIFF
--- a/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp
+++ b/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp
@@ -347,7 +347,7 @@ void Action::updateUserpicsFromContent() {
 }
 
 void Action::populateSubmenu() {
-	if (_content.participants.size() < 1) {
+	if (_content.participants.size() < 1 || !isEnabled()) {
 		_submenu.clear();
 		_parentMenu->removeSubmenu(action());
 		if (!isEnabled()) {
@@ -360,7 +360,15 @@ void Action::populateSubmenu() {
 		action(),
 		st::whoReadMenu);
 	_submenu.populate(submenu, _content);
-	_parentMenu->checkSubmenuShow();
+	if (isSelected() && lastTriggeredSource() == Menu::TriggeredSource::Mouse) {
+		PostponeCall(this, [=] {
+			if (isEnabled()
+				&& isSelected()
+				&& lastTriggeredSource() == Menu::TriggeredSource::Mouse) {
+				_parentMenu->checkSubmenuShow();
+			}
+		});
+	}
 }
 
 void Action::paint(Painter &p) {


### PR DESCRIPTION
## Summary
- guard who-read submenu population while the action is still loading or disabled
- defer auto-opening the submenu until the next event loop tick and re-check that the row is still selected/enabled

This avoids opening the read-receipts submenu from inside the async content update path, which matches the crash scenario described in #377 when hovering the who-read row while it is still loading.

Fixes #377.

## Verification
- Ran `git diff --check`
- Full AyuGram Desktop build was not run locally because this checkout does not include the full dependency/build environment.