### PR TITLE
Allow restoring hidden translate bar

### DIFF
--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -968,14 +968,8 @@ void Filler::addTranslate() {
 		|| !Core::App().settings().translateChatEnabled()) {
 		return;
 	}
-	const auto history = _peer->owner().historyLoaded(_peer);
-	if (!history
-		|| !history->translateOfferedFrom()
-		|| history->translatedTo()) {
-		return;
-	}
-	_addAction(tr::lng_context_translate(tr::now), [=] {
-		history->peer->saveTranslationDisabled(false);
+	_addAction(tr::lng_translate_settings_show(tr::now), [=] {
+		_peer->saveTranslationDisabled(false);
 	}, &st::menuIconTranslate);
 }
 


### PR DESCRIPTION
## Summary
- keep the peer menu restore action available whenever translations are hidden for that peer
- remove the dependency on a loaded history, detected source language, or current translated state
- use the existing "Show Translate Button" label for the restore action

This makes the hide action reversible from the peer menu and addresses #291.

Fixes #291.

## Verification
- Ran `git diff --check`
- Full AyuGram Desktop build was not run locally because this checkout does not include the full dependency/build environment.