### PR TITLE
Show delete-own-messages action for group admins

### DIFF
--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -444,11 +444,11 @@ void AddDeleteOwnMessagesAction(PeerData *peerData,
 		return;
 	}
 	if (const auto chat = peerData->asChat()) {
-		if (!chat->amIn() || chat->amCreator() || chat->hasAdminRights()) {
+		if (!chat->amIn()) {
 			return;
 		}
 	} else if (const auto channel = peerData->asChannel()) {
-		if (!channel->isMegagroup() || !channel->amIn() || channel->amCreator() || channel->hasAdminRights()) {
+		if (!channel->isMegagroup() || !channel->amIn()) {
 			return;
 		}
 	} else {


### PR DESCRIPTION
## Summary
- allow the AyuGram "Delete own messages" menu action for group and megagroup admins
- keep the existing restrictions that the peer must be a group/megagroup and the current user must still be a member

The previous check excluded creators and users with admin rights, which made the action disappear for admins as reported in #359.

Fixes #359.

## Verification
- Ran `git diff --check`
- Full AyuGram Desktop build was not run locally because this checkout does not include the full dependency/build environment.