### PR TITLE
fix: show delete own messages option for admins and creators in groups

### DIFF
--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -444,11 +444,11 @@ void AddDeleteOwnMessagesAction(PeerData *peerData,
 		return;
 	}
 	if (const auto chat = peerData->asChat()) {
-		if (!chat->amIn() || chat->amCreator() || chat->hasAdminRights()) {
+		if (!chat->amIn()) {
 			return;
 		}
 	} else if (const auto channel = peerData->asChannel()) {
-		if (!channel->isMegagroup() || !channel->amIn() || channel->amCreator() || channel->hasAdminRights()) {
+		if (!channel->isMegagroup() || !channel->amIn()) {
 			return;
 		}
 	} else {


### PR DESCRIPTION
## Summary

- Fixes `AddDeleteOwnMessagesAction` incorrectly hiding the "Delete all my messages" menu option for group admins and creators
- Removed `amCreator()` and `hasAdminRights()` checks — being an admin does not replace this feature, since the moderation "delete all from user" tool only works for *other* users' messages, not your own

Closes #359

---
*This PR was AI generated.*