### PR TITLE
fix: save expired TTL messages deleted via auto-delete in groups

### DIFF
--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -3914,7 +3914,7 @@ void HistoryItem::applyTTL(TimeId destroyAt) {
 		const auto session = &_history->session();
 		crl::on_main(session, [session, id = fullId()]{
 			if (const auto item = session->data().message(id)) {
-				item->destroy();
+				processMessageDelete(item);
 			}
 		});
 	} else {


### PR DESCRIPTION
## Summary

- When a group has auto-delete enabled, messages receive a `ttlDestroyAt` timestamp
- If the app restarts (or messages are scrolled into view) after the TTL has already expired, `applyTTL` takes the `now >= _ttlDestroyAt` branch and schedules `item->destroy()` via `crl::on_main` — bypassing `processMessageDelete` entirely
- This means AyuGram never gets a chance to save the message to the deleted messages database

## Fix

Replace `item->destroy()` with `processMessageDelete(item)` in the expired-TTL path of `applyTTL`. `telegram_helpers.h` (which declares `processMessageDelete`) was already included in `history_item.cpp`.

Closes #300

---
*This PR was AI generated.*