### PR TITLE
fix: remove deleted messages from shared media index to fix incorrect counts

### DIFF
--- a/Telegram/SourceFiles/history/history_item.cpp
+++ b/Telegram/SourceFiles/history/history_item.cpp
@@ -3676,6 +3676,8 @@ void HistoryItem::setDeleted() {
 		}
 	}
 
+	removeFromSharedMediaIndex();
+
 	if (isService()) {
 		const auto &settings = AyuSettings::getInstance();
 		setAyuHint(settings.deletedMark());


### PR DESCRIPTION
## Summary

- When `saveDeletedMessages` is on, messages are kept in memory via `setDeleted()` instead of `destroy()`
- `destroy()` goes through `History::destroyMessage()` which dispatches `SharedMediaRemoveOne` to update the Photos/Links/Files counts in the peer profile
- `setDeleted()` did not call `removeFromSharedMediaIndex()`, so deleted messages remained counted in the shared media totals
- The counts would only reset on app restart (when the in-memory items are gone)

## Fix

Call `removeFromSharedMediaIndex()` at the end of `setDeleted()` so the shared media counts stay accurate when a message is marked as deleted.

Closes #174

---
*This PR was AI generated.*