### PR TITLE
fix: avoid redrawing all desktop icons on launch

### DIFF
--- a/Telegram/SourceFiles/ayu/utils/windows_utils.cpp
+++ b/Telegram/SourceFiles/ayu/utils/windows_utils.cpp
@@ -35,7 +35,18 @@ void processIcon(QString shortcut, QString iconPath) {
 
 			if (SUCCEEDED(pPersistFile->Load(shortcutPath.c_str(), STGM_READWRITE))) {
 				pShellLink->SetIconLocation(iconPath.toStdWString().c_str(), 0);
-				pPersistFile->Save(shortcutPath.c_str(), TRUE);
+				if (SUCCEEDED(pPersistFile->Save(shortcutPath.c_str(), TRUE))) {
+					// Notify the shell that only this shortcut changed so its
+					// icon is refreshed. Using SHCNE_UPDATEITEM (instead of the
+					// global SHCNE_ASSOCCHANGED) avoids flushing the entire
+					// system icon cache, which redrew every desktop icon on
+					// each launch (see AyuGram/AyuGramDesktop#392).
+					SHChangeNotify(
+						SHCNE_UPDATEITEM,
+						SHCNF_PATHW,
+						shortcutPath.c_str(),
+						nullptr);
+				}
 			}
 
 			pPersistFile->Release();
@@ -162,8 +173,6 @@ void reloadAppIconFromTaskBar() {
 	processNewPinned(iconPath);
 	processNewShortcuts(iconPath);
 	processLegacy(iconPath);
-
-	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, NULL, NULL);
 }
 
 #endif


### PR DESCRIPTION
`reloadAppIconFromTaskBar()` ran on every Windows startup and ended with `SHChangeNotify(SHCNE_ASSOCCHANGED, ...)`, which signals a file-association change and forces the shell to flush the entire system icon cache — redrawing every desktop and taskbar icon on each launch.

Replace the single global broadcast with a targeted `SHCNE_UPDATEITEM` notification for each shortcut that was actually rewritten, so only AyuGram's own shortcut icons refresh.

Fixes #392.

This PR was AI generated.
