### PR TITLE
fix: Mini Apps crash on NVIDIA + Wayland (disable WebKitGTK DMABUF renderer)

### DIFF
--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
@@ -757,6 +757,16 @@ void start() {
 		"PULSE_PROP_application.icon_name",
 		ApplicationIconName().toUtf8());
 
+	// WebKitGTK's DMABUF renderer crashes the web process immediately on the
+	// proprietary NVIDIA driver under Wayland, so Mini Apps open as frozen,
+	// empty windows that can't be closed. Disabling it falls back to a working
+	// buffer-sharing path. The webview helper subprocess inherits this from our
+	// environment, and WebKitGTK is used nowhere else in the app.
+	// https://github.com/AyuGram/AyuGramDesktop/issues/393
+	if (!qEnvironmentVariableIsSet("WEBKIT_DISABLE_DMABUF_RENDERER")) {
+		qputenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+	}
+
 	GLib::set_prgname(cExeName().toStdString());
 	GLib::set_application_name(AppName.data());
 


### PR DESCRIPTION
### Closes #393

### Problem
On Wayland (tiling compositors such as Hyprland) with the proprietary NVIDIA driver, launching any Mini App (Telegraph, Wallet, …) opens a frozen, empty window. Both the Mini App and the main window become unresponsive and have to be killed with `pkill -9`. The log shows the webview's web process dying immediately, after which `BotWebView` posts events to it:

```
BotWebView Error: Post event "fullscreen_changed" on crashed webview.
BotWebView Error: Post event "safe_area_changed" on crashed webview.
```

The affected setup reports `OpenGL ES 3.2 NVIDIA 580.159.04`.

### Root cause
Mini Apps render via WebKitGTK in a helper subprocess. WebKitGTK's default **DMA-BUF / GBM renderer** crashes the web process immediately on the proprietary NVIDIA driver under Wayland. `lib_webview` only disables GL for the *Raster* backend, so with NVIDIA's *OpenGL* backend the crash-prone DMA-BUF path stays active. This is a well-known WebKitGTK/NVIDIA issue (see [WebKit bug 262607](https://bugs.webkit.org/show_bug.cgi?id=262607)).

### Fix
Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at Linux startup in `Platform::start()`, which makes WebKitGTK fall back to a working buffer-sharing path. The webview helper is spawned as a subprocess that inherits this environment, and WebKitGTK is used **only** for Mini Apps, so nothing else in the app is affected. The value is only set when the user hasn't already defined it, so it stays overridable.

`lib_webview` is an upstream-pinned submodule, so the fix is applied in AyuGram's own source rather than the submodule.

### Testing
This is an NVIDIA/Wayland-specific GPU-driver crash and could not be reproduced on the development machine. Verification would be confirming a Mini App now opens normally on affected hardware.

---
This PR was AI generated.