### PR TITLE
feat: persist streamer mode across restarts

### DIFF
--- a/Telegram/SourceFiles/ayu/ayu_infra.cpp
+++ b/Telegram/SourceFiles/ayu/ayu_infra.cpp
@@ -11,6 +11,7 @@
 #include "ayu/ayu_ui_settings.h"
 #include "ayu/ayu_worker.h"
 #include "ayu/data/ayu_database.h"
+#include "ayu/features/streamer_mode/streamer_mode.h"
 #include "ayu/ui/ayu_logo.h"
 #include "features/translator/ayu_translator.h"
 #include "lang/lang_instance.h"
@@ -60,6 +61,12 @@ void initTranslator() {
 	Ayu::Translator::TranslateManager::init();
 }
 
+void initStreamerMode() {
+	if (AyuSettings::getInstance().streamerMode()) {
+		AyuFeatures::StreamerMode::enable();
+	}
+}
+
 void initIcon() {
 #ifdef Q_OS_WIN
 	AyuAssets::loadAppIco();
@@ -75,6 +82,7 @@ void init() {
 	initWorker();
 	initRCManager();
 	initTranslator();
+	initStreamerMode();
 }
 
 }

--- a/Telegram/SourceFiles/ayu/ayu_settings.cpp
+++ b/Telegram/SourceFiles/ayu/ayu_settings.cpp
@@ -1050,6 +1050,12 @@ void AyuSettings::setSingleCornerRadius(bool val) {
 	save();
 }
 
+void AyuSettings::setStreamerMode(bool val) {
+	if (_streamerMode.current() == val) return;
+	_streamerMode = val;
+	save();
+}
+
 void to_json(nlohmann::json &j, const AyuSettings &s) {
 	auto ghostAccounts = nlohmann::json::object();
 	for (const auto &[key, value] : s._ghostAccounts) {
@@ -1142,6 +1148,7 @@ void to_json(nlohmann::json &j, const AyuSettings &s) {
 		{"crashReporting", s._crashReporting.current()},
 		{"avatarCorners", s._avatarCorners.current()},
 		{"singleCornerRadius", s._singleCornerRadius.current()},
+		{"streamerMode", s._streamerMode.current()},
 		{"messageShotSettings", s._messageShotSettings}
 	};
 }
@@ -1242,6 +1249,7 @@ void from_json(const nlohmann::json &j, AyuSettings &s) {
 	s._crashReporting = j.value("crashReporting", defaults._crashReporting.current());
 	s._avatarCorners = j.value("avatarCorners", defaults._avatarCorners.current());
 	s._singleCornerRadius = j.value("singleCornerRadius", defaults._singleCornerRadius.current());
+	s._streamerMode = j.value("streamerMode", defaults._streamerMode.current());
 
 	if (j.contains("messageShotSettings") && j["messageShotSettings"].is_object()) {
 		j["messageShotSettings"].get_to(s._messageShotSettings);

--- a/Telegram/SourceFiles/ayu/ayu_settings.h
+++ b/Telegram/SourceFiles/ayu/ayu_settings.h
@@ -350,6 +350,7 @@ public:
 	[[nodiscard]] bool crashReporting() const { return _crashReporting.current(); }
 	[[nodiscard]] int avatarCorners() const { return _avatarCorners.current(); }
 	[[nodiscard]] bool singleCornerRadius() const { return _singleCornerRadius.current(); }
+	[[nodiscard]] bool streamerMode() const { return _streamerMode.current(); }
 
 	void setSaveDeletedMessages(bool val);
 	void setSaveMessagesHistory(bool val);
@@ -434,6 +435,7 @@ public:
 	void setCrashReporting(bool val);
 	void setAvatarCorners(int val);
 	void setSingleCornerRadius(bool val);
+	void setStreamerMode(bool val);
 
 	[[nodiscard]] rpl::producer<bool> useGlobalGhostModeValue() const { return _useGlobalGhostMode.value(); }
 	[[nodiscard]] rpl::producer<bool> useGlobalGhostModeChanges() const { return _useGlobalGhostMode.changes(); }
@@ -603,6 +605,8 @@ public:
 	[[nodiscard]] rpl::producer<int> avatarCornersChanges() const { return _avatarCorners.changes(); }
 	[[nodiscard]] rpl::producer<bool> singleCornerRadiusValue() const { return _singleCornerRadius.value(); }
 	[[nodiscard]] rpl::producer<bool> singleCornerRadiusChanges() const { return _singleCornerRadius.changes(); }
+	[[nodiscard]] rpl::producer<bool> streamerModeValue() const { return _streamerMode.value(); }
+	[[nodiscard]] rpl::producer<bool> streamerModeChanges() const { return _streamerMode.changes(); }
 
 	friend void to_json(nlohmann::json &j, const AyuSettings &s);
 	friend void from_json(const nlohmann::json &j, AyuSettings &s);
@@ -696,6 +700,7 @@ private:
 	rpl::variable<bool> _crashReporting = true;
 	rpl::variable<int> _avatarCorners = 23;
 	rpl::variable<bool> _singleCornerRadius = false;
+	rpl::variable<bool> _streamerMode = false;
 
 	rpl::variable<bool> _useGlobalGhostMode = true;
 	std::map<uint64, std::unique_ptr<GhostModeAccountSettings>> _ghostAccounts;

--- a/Telegram/SourceFiles/ayu/features/streamer_mode/streamer_mode.cpp
+++ b/Telegram/SourceFiles/ayu/features/streamer_mode/streamer_mode.cpp
@@ -7,6 +7,7 @@
 
 #include "ayu/features/streamer_mode/streamer_mode.h"
 
+#include "ayu/ayu_settings.h"
 #include "window/window_controller.h"
 
 #if defined Q_OS_WINRT || defined Q_OS_WIN
@@ -31,12 +32,14 @@ void enable()
 {
 	isEnabledVal = true;
 	Impl::enableHook();
+	AyuSettings::getInstance().setStreamerMode(true);
 }
 
 void disable()
 {
 	isEnabledVal = false;
 	Impl::disableHook();
+	AyuSettings::getInstance().setStreamerMode(false);
 }
 
 void hideWidgetWindow(QWidget *widget)


### PR DESCRIPTION
Closes #177

### Problem

Streamer mode is a runtime-only flag (`isEnabledVal` in `streamer_mode.cpp`) and is not persisted, so it always resets to off after restarting the app.

### Solution

- Add a persisted `streamerMode` boolean to `AyuSettings` (getter/setter, value/changes producers, JSON (de)serialization), mirroring the existing boolean-setting pattern.
- Persist the state centrally inside `StreamerMode::enable()` / `disable()` so both toggle entry points (main menu and tray) stay in sync. The temporary `hideWidgetWindow` / `showWidgetWindow` helpers are untouched, so per-window hiding during media viewing does not affect the persisted state.
- Restore the state on startup via a new `AyuInfra::initStreamerMode()` called from `AyuInfra::init()`. At that point no windows exist yet, but `Application::processCreatedWindow()` already applies the capture-exclusion hook to each window it creates while streamer mode is enabled, so the mode is correctly applied as windows come up.

### Notes

This PR was AI generated.

> ⚠️ Not yet built/tested locally (the build was intentionally avoided per `AGENTS.md`). Kept as a draft until verified with a local build. Changes follow the existing settings and streamer-mode patterns.