### PR TITLE
feat: add option to disable global search

### DIFF
--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -8036,6 +8036,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "ayu_DisableAds" = "Disable Ads";
 "ayu_DisableStories" = "Disable Stories";
 "ayu_DisableOpenLinkWarning" = "Disable Open Link Warning";
+"ayu_DisableGlobalSearch" = "Disable Global Search";
 "ayu_DisableCustomBackgrounds" = "Disable Custom Backgrounds";
 "ayu_HidePremiumStatuses" = "Hide Premium Statuses";
 "ayu_SmoothScroll" = "Smooth Scroll";

--- a/Telegram/SourceFiles/ayu/ayu_settings.cpp
+++ b/Telegram/SourceFiles/ayu/ayu_settings.cpp
@@ -1050,6 +1050,12 @@ void AyuSettings::setSingleCornerRadius(bool val) {
 	save();
 }
 
+void AyuSettings::setDisableGlobalSearch(bool val) {
+	if (_disableGlobalSearch.current() == val) return;
+	_disableGlobalSearch = val;
+	save();
+}
+
 void to_json(nlohmann::json &j, const AyuSettings &s) {
 	auto ghostAccounts = nlohmann::json::object();
 	for (const auto &[key, value] : s._ghostAccounts) {
@@ -1142,6 +1148,7 @@ void to_json(nlohmann::json &j, const AyuSettings &s) {
 		{"crashReporting", s._crashReporting.current()},
 		{"avatarCorners", s._avatarCorners.current()},
 		{"singleCornerRadius", s._singleCornerRadius.current()},
+		{"disableGlobalSearch", s._disableGlobalSearch.current()},
 		{"messageShotSettings", s._messageShotSettings}
 	};
 }
@@ -1242,6 +1249,7 @@ void from_json(const nlohmann::json &j, AyuSettings &s) {
 	s._crashReporting = j.value("crashReporting", defaults._crashReporting.current());
 	s._avatarCorners = j.value("avatarCorners", defaults._avatarCorners.current());
 	s._singleCornerRadius = j.value("singleCornerRadius", defaults._singleCornerRadius.current());
+	s._disableGlobalSearch = j.value("disableGlobalSearch", defaults._disableGlobalSearch.current());
 
 	if (j.contains("messageShotSettings") && j["messageShotSettings"].is_object()) {
 		j["messageShotSettings"].get_to(s._messageShotSettings);

--- a/Telegram/SourceFiles/ayu/ayu_settings.h
+++ b/Telegram/SourceFiles/ayu/ayu_settings.h
@@ -350,6 +350,7 @@ public:
 	[[nodiscard]] bool crashReporting() const { return _crashReporting.current(); }
 	[[nodiscard]] int avatarCorners() const { return _avatarCorners.current(); }
 	[[nodiscard]] bool singleCornerRadius() const { return _singleCornerRadius.current(); }
+	[[nodiscard]] bool disableGlobalSearch() const { return _disableGlobalSearch.current(); }
 
 	void setSaveDeletedMessages(bool val);
 	void setSaveMessagesHistory(bool val);
@@ -434,6 +435,7 @@ public:
 	void setCrashReporting(bool val);
 	void setAvatarCorners(int val);
 	void setSingleCornerRadius(bool val);
+	void setDisableGlobalSearch(bool val);
 
 	[[nodiscard]] rpl::producer<bool> useGlobalGhostModeValue() const { return _useGlobalGhostMode.value(); }
 	[[nodiscard]] rpl::producer<bool> useGlobalGhostModeChanges() const { return _useGlobalGhostMode.changes(); }
@@ -603,6 +605,8 @@ public:
 	[[nodiscard]] rpl::producer<int> avatarCornersChanges() const { return _avatarCorners.changes(); }
 	[[nodiscard]] rpl::producer<bool> singleCornerRadiusValue() const { return _singleCornerRadius.value(); }
 	[[nodiscard]] rpl::producer<bool> singleCornerRadiusChanges() const { return _singleCornerRadius.changes(); }
+	[[nodiscard]] rpl::producer<bool> disableGlobalSearchValue() const { return _disableGlobalSearch.value(); }
+	[[nodiscard]] rpl::producer<bool> disableGlobalSearchChanges() const { return _disableGlobalSearch.changes(); }
 
 	friend void to_json(nlohmann::json &j, const AyuSettings &s);
 	friend void from_json(const nlohmann::json &j, AyuSettings &s);
@@ -696,6 +700,7 @@ private:
 	rpl::variable<bool> _crashReporting = true;
 	rpl::variable<int> _avatarCorners = 23;
 	rpl::variable<bool> _singleCornerRadius = false;
+	rpl::variable<bool> _disableGlobalSearch = false;
 
 	rpl::variable<bool> _useGlobalGhostMode = true;
 	std::map<uint64, std::unique_ptr<GhostModeAccountSettings>> _ghostAccounts;

--- a/Telegram/SourceFiles/ayu/ui/settings/settings_general.cpp
+++ b/Telegram/SourceFiles/ayu/ui/settings/settings_general.cpp
@@ -181,6 +181,13 @@ void BuildQoLToggles(SectionBuilder &builder, AyuSectionBuilder &ayu) {
 		.setter = &AyuSettings::setDisableOpenLinkWarning,
 	});
 
+	ayu.addSettingToggle({
+		.id = u"ayu/disableGlobalSearch"_q,
+		.title = tr::ayu_DisableGlobalSearch(),
+		.getter = &AyuSettings::disableGlobalSearch,
+		.setter = &AyuSettings::setDisableGlobalSearch,
+	});
+
 	ayu.addCollapsibleToggle({
 		.id = u"ayu/similarChannels"_q,
 		.title = tr::ayu_DisableSimilarChannels(),

--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
@@ -2891,7 +2891,9 @@ bool Widget::search(bool inCache, SearchRequestDelay delay) {
 }
 
 bool Widget::peerSearchRequired() const {
-	return _searchState.filterChatsList() && !_openedForum;
+	return _searchState.filterChatsList()
+		&& !_openedForum
+		&& !AyuSettings::getInstance().disableGlobalSearch();
 }
 
 bool Widget::searchForTopicsRequired(const QString &query) const {


### PR DESCRIPTION
Closes #164

### Problem

There is no way to disable global (public) search results in the chats search. Typing a query always queries the server for public chats/channels/users, which some users find distracting and would like to turn off (64Gram offers the same option).

### Solution

- Add a persisted `disableGlobalSearch` boolean to `AyuSettings` (getter/setter, value/changes producers, JSON (de)serialization), following the existing boolean-setting pattern.
- Gate the global peer search in `Dialogs::Widget::peerSearchRequired()`: when the option is on, the function returns `false`, so the dialogs widget calls `peerSearchReceived({})` and no global/public results are shown. Local chat-list filtering, in-chat message search and search-by-ID are unaffected.
- Add a toggle under Settings → AyuGram → General (`BuildQoLToggles`), next to the other "Disable …" behavior toggles, with the `ayu_DisableGlobalSearch` lang string.

### Notes

This PR was AI generated.

> ⚠️ Not yet built/tested locally (the build was intentionally avoided per `AGENTS.md`). Kept as a draft until verified with a local build. Changes follow the existing settings and dialogs-search patterns.