### PR TITLE
docs: update Gentoo overlay link to active maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Install `ayugram-desktop` from [nixpkgs](https://search.nixos.org/packages?chann
 
 ### Gentoo Linux
 
-See [this repository](https://codeberg.org/OverLessArtem/ayugram-ebuild-gentoo) for installation manual.
+See [this repository](https://github.com/Gur0v/ayugram-overlay) for installation manual.
 
 ### Void Linux
 See [this repository](https://codeberg.org/OverLessArtem/ayugram-template-void) for installation manual.


### PR DESCRIPTION
The Codeberg Gentoo overlay linked in the README hasn't been updated in a while, so I've forked it and picked up maintenance.

Changes in this fork:
- Updated ebuilds to v6.7.8
- Added a `-bin` package built directly from upstream via GitHub Actions (workflow included in the repo), for anyone who'd rather skip compile times

I've been running this fork for about a month now and everything's stable: binaries install cleanly, the build workflow runs without issues, and the ebuilds work as expected. Should be ready for general use.