### PR TITLE
fix: save and display media in message history

### DIFF
--- a/Telegram/SourceFiles/ayu/data/messages_storage.cpp
+++ b/Telegram/SourceFiles/ayu/data/messages_storage.cpp
@@ -10,11 +10,15 @@
 #include "ayu/utils/ayu_mapper.h"
 #include "ayu/utils/telegram_helpers.h"
 #include "base/unixtime.h"
+#include "data/data_document.h"
 #include "data/data_forum_topic.h"
+#include "data/data_media_types.h"
+#include "data/data_photo.h"
 #include "data/data_session.h"
 #include "history/history.h"
 #include "history/history_item.h"
 #include "history/history_item_components.h"
+#include "lang/lang_keys.h"
 #include "main/main_session.h"
 
 namespace AyuMessages {
@@ -74,14 +78,7 @@ void map(not_null<HistoryItem*> item, AyuMessageBase &message) {
 	message.text = serializedText.first;
 	message.textEntities = serializedText.second;
 
-	// todo: implement mapping
-	message.mediaPath = "/";
-	// message.hqThumbPath
-	message.documentType = 0; // document type none
-	// message.documentSerialized
-	// message.thumbsSerialized
-	// message.documentAttributesSerialized
-	// message.mimeType
+	AyuMapper::mapMediaToMessage(item, message);
 }
 
 void addEditedMessage(not_null<HistoryItem *> item) {
@@ -116,7 +113,33 @@ void addDeletedMessage(not_null<HistoryItem*> item) {
 	map(item, message);
 
 	if (message.text.empty()) {
-		return;
+		const auto media = item->media();
+		if (!media) {
+			return;
+		}
+		if (media->photo()) {
+			message.text = tr::lng_in_dlg_photo(tr::now).toStdString();
+		} else if (const auto document = media->document()) {
+			const auto type = [&] {
+				if (document->isVideoMessage()) {
+					return tr::lng_in_dlg_video_message(tr::now);
+				} else if (document->isAnimation()) {
+					return u"GIF"_q;
+				} else if (document->isVideoFile()) {
+					return tr::lng_in_dlg_video(tr::now);
+				} else if (document->isVoiceMessage()) {
+					return tr::lng_in_dlg_audio(tr::now);
+				} else if (document->sticker()) {
+					return tr::lng_in_dlg_sticker(tr::now);
+				} else if (document->isAudioFile()) {
+					return tr::lng_in_dlg_audio_file(tr::now);
+				}
+				return tr::lng_in_dlg_file(tr::now);
+			}();
+			message.text = type.toStdString();
+		} else {
+			return;
+		}
 	}
 
 	AyuDatabase::addDeletedMessage(message);

--- a/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
+++ b/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
@@ -17,6 +17,9 @@
 #include "data/data_channel.h"
 #include "data/data_file_origin.h"
 #include "data/data_forum_topic.h"
+#include "data/data_document.h"
+#include "data/data_photo.h"
+#include "data/stickers/data_stickers_set.h"
 #include "data/data_session.h"
 #include "data/data_user.h"
 #include "history/history.h"
@@ -82,7 +85,159 @@ void GenerateItems(
 		return callback(OwnedItem(delegate, item), sentDate, realId);
 	};
 
-	const auto makeSimpleTextMessage = [&](TextWithEntities &&text)
+	const auto resolveMedia = [&]() -> MTPMessageMedia {
+		if (message.documentType == AyuMapper::kDocumentTypeNone
+			|| message.documentSerialized.empty()) {
+			return MTP_messageMediaEmpty();
+		}
+
+		if (message.documentType == AyuMapper::kDocumentTypePhoto) {
+			auto result = MTP_messageMediaEmpty();
+			AyuMapper::deserializeObject<MTPInputPhoto>(
+				message.documentSerialized
+			).match([&](const MTPDinputPhoto &inp) {
+				const auto photo = history->owner().photo(inp.vid().v);
+				if (!photo->hasExact(Data::PhotoSize::Large)) {
+					return;
+				}
+				photo->mtpInput().match([&](const MTPDinputPhoto &pi) {
+					using Flag = MTPDmessageMediaPhoto::Flag;
+					result = MTP_messageMediaPhoto(
+						MTP_flags(Flag::f_photo),
+						MTP_photo(
+							MTP_flags(0),
+							MTP_long(photo->id),
+							MTP_long(pi.vaccess_hash().v),
+							MTP_bytes(pi.vfile_reference().v),
+							MTP_int(photo->date()),
+							MTP_vector<MTPPhotoSize>(),
+							MTPVector<MTPVideoSize>(),
+							MTP_int(photo->getDC())),
+						MTPint(),
+						MTPDocument());
+				}, [](const MTPDinputPhotoEmpty &) {});
+			}, [](const MTPDinputPhotoEmpty &) {});
+			return result;
+		}
+
+		const auto buildDocumentAttributes = [](
+			not_null<DocumentData*> doc) -> QVector<MTPDocumentAttribute>
+		{
+			auto attrs = QVector<MTPDocumentAttribute>();
+			const auto filename = doc->filename();
+			if (!filename.isEmpty()) {
+				attrs.push_back(MTP_documentAttributeFilename(
+					MTP_string(filename)));
+			}
+			const auto dims = doc->dimensions;
+			if (dims.width() > 0 && dims.height() > 0) {
+				if (doc->hasDuration() && !doc->hasMimeType(u"image/gif"_q)) {
+					auto flags = MTPDdocumentAttributeVideo::Flags(0);
+					using VideoFlag = MTPDdocumentAttributeVideo::Flag;
+					if (doc->isVideoMessage()) {
+						flags |= VideoFlag::f_round_message;
+					}
+					if (doc->supportsStreaming()) {
+						flags |= VideoFlag::f_supports_streaming;
+					}
+					attrs.push_back(MTP_documentAttributeVideo(
+						MTP_flags(flags),
+						MTP_double(doc->duration() / 1000.),
+						MTP_int(dims.width()),
+						MTP_int(dims.height()),
+						MTPint(),
+						MTPdouble(),
+						MTPstring()));
+				} else {
+					attrs.push_back(MTP_documentAttributeImageSize(
+						MTP_int(dims.width()),
+						MTP_int(dims.height())));
+				}
+			} else if (doc->hasDuration() && (doc->isVideoFile() || doc->isVideoMessage())) {
+				auto flags = MTPDdocumentAttributeVideo::Flags(0);
+				using VideoFlag = MTPDdocumentAttributeVideo::Flag;
+				if (doc->isVideoMessage()) {
+					flags |= VideoFlag::f_round_message;
+				}
+				if (doc->supportsStreaming()) {
+					flags |= VideoFlag::f_supports_streaming;
+				}
+				attrs.push_back(MTP_documentAttributeVideo(
+					MTP_flags(flags),
+					MTP_double(doc->duration() / 1000.),
+					MTP_int(0),
+					MTP_int(0),
+					MTPint(),
+					MTPdouble(),
+					MTPstring()));
+			}
+			if (doc->type == AnimatedDocument) {
+				attrs.push_back(MTP_documentAttributeAnimated());
+			} else if (doc->type == StickerDocument) {
+				if (const auto sticker = doc->sticker()) {
+					attrs.push_back(MTP_documentAttributeSticker(
+						MTP_flags(0),
+						MTP_string(sticker->alt),
+						Data::InputStickerSet(sticker->set),
+						MTPMaskCoords()));
+				}
+			} else if (const auto song = doc->song()) {
+				const auto flags = MTPDdocumentAttributeAudio::Flag::f_title
+					| MTPDdocumentAttributeAudio::Flag::f_performer;
+				attrs.push_back(MTP_documentAttributeAudio(
+					MTP_flags(flags),
+					MTP_int(int(doc->duration() / 1000)),
+					MTP_string(song->title),
+					MTP_string(song->performer),
+					MTPstring()));
+			} else if (doc->voice()) {
+				attrs.push_back(MTP_documentAttributeAudio(
+					MTP_flags(MTPDdocumentAttributeAudio::Flag::f_voice),
+					MTP_int(int(doc->duration() / 1000)),
+					MTPstring(),
+					MTPstring(),
+					MTPbytes()));
+			}
+			return attrs;
+		};
+
+		auto result = MTP_messageMediaEmpty();
+		AyuMapper::deserializeObject<MTPInputDocument>(
+			message.documentSerialized
+		).match([&](const MTPDinputDocument &inp) {
+			const auto doc = history->owner().document(inp.vid().v);
+			if (!doc->hasRemoteLocation()) {
+				return;
+			}
+			doc->mtpInput().match([&](const MTPDinputDocument &di) {
+				using Flag = MTPDmessageMediaDocument::Flag;
+				result = MTP_messageMediaDocument(
+					MTP_flags(Flag::f_document),
+					MTP_document(
+						MTP_flags(0),
+						MTP_long(doc->id),
+						MTP_long(di.vaccess_hash().v),
+						MTP_bytes(doc->fileReference()),
+						MTP_int(doc->date),
+						MTP_string(doc->mimeString()),
+						MTP_long(doc->size),
+						MTP_vector<MTPPhotoSize>(),
+						MTPVector<MTPVideoSize>(),
+						MTP_int(doc->getDC()),
+						MTP_vector<MTPDocumentAttribute>(
+							buildDocumentAttributes(doc))),
+					MTPVector<MTPDocument>(),
+					MTPPhoto(),
+					MTPint(),
+					MTPint());
+			}, [](const MTPDinputDocumentEmpty &) {});
+		}, [](const MTPDinputDocumentEmpty &) {});
+		return result;
+	};
+
+	const auto makeSimpleTextMessage = [&](
+		TextWithEntities &&text,
+		MTPMessageMedia &&media)
 	{
 		base::flags<MessageFlag> flags = MessageFlag::AdminLogEntry;
 		if (from) {
@@ -106,12 +261,12 @@ void GenerateItems(
 																: QString("unknown user: %1").arg(message.fromId),
 									},
 									std::move(text),
-									MTP_messageMediaEmpty());
+									std::move(media));
 	};
 
 	const auto addSimpleTextMessage = [&](TextWithEntities &&text)
 	{
-		addPart(makeSimpleTextMessage(std::move(text)));
+		addPart(makeSimpleTextMessage(std::move(text), resolveMedia()));
 	};
 
 	const auto text = QString::fromStdString(message.text);

--- a/Telegram/SourceFiles/ayu/utils/ayu_mapper.cpp
+++ b/Telegram/SourceFiles/ayu/utils/ayu_mapper.cpp
@@ -8,6 +8,9 @@
 
 #include "apiwrap.h"
 #include "api/api_text_entities.h"
+#include "data/data_document.h"
+#include "data/data_media_types.h"
+#include "data/data_photo.h"
 #include "history/history.h"
 #include "history/history_item.h"
 #include "history/history_item_components.h"
@@ -206,6 +209,40 @@ int mapItemFlagsToMTPFlags(not_null<HistoryItem*> item) {
 	}
 
 	return flags;
+}
+
+void mapMediaToMessage(not_null<HistoryItem*> item, AyuMessageBase &message) {
+	const auto media = item->media();
+	if (!media) {
+		return;
+	}
+
+	if (const auto photo = media->photo()) {
+		message.documentType = kDocumentTypePhoto;
+		message.documentSerialized = serializeObject(photo->mtpInput());
+	} else if (const auto document = media->document()) {
+		if (document->isVideoMessage()) {
+			message.documentType = kDocumentTypeVideoNote;
+		} else if (document->isAnimation()) {
+			message.documentType = kDocumentTypeAnimation;
+		} else if (document->isVideoFile()) {
+			message.documentType = kDocumentTypeVideo;
+		} else if (document->isVoiceMessage()) {
+			message.documentType = kDocumentTypeVoice;
+		} else if (document->sticker()) {
+			message.documentType = kDocumentTypeSticker;
+		} else if (document->isAudioFile()) {
+			message.documentType = kDocumentTypeAudio;
+		} else {
+			message.documentType = kDocumentTypeFile;
+		}
+		message.mimeType = document->mimeString().toStdString();
+		message.documentSerialized = serializeObject(document->mtpInput());
+		const auto location = document->location(true);
+		if (!location.isEmpty()) {
+			message.mediaPath = location.name().toStdString();
+		}
+	}
 }
 
 }

--- a/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
+++ b/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
@@ -6,7 +6,21 @@
 // Copyright @Radolyn, 2026
 #pragma once
 
+#include "ayu/data/entities.h"
+
+class HistoryItem;
+
 namespace AyuMapper {
+
+constexpr int kDocumentTypeNone = 0;
+constexpr int kDocumentTypePhoto = 1;
+constexpr int kDocumentTypeVideoNote = 2;
+constexpr int kDocumentTypeAnimation = 3;
+constexpr int kDocumentTypeVideo = 4;
+constexpr int kDocumentTypeVoice = 5;
+constexpr int kDocumentTypeSticker = 6;
+constexpr int kDocumentTypeAudio = 7;
+constexpr int kDocumentTypeFile = 8;
 
 template<typename MTPObject>
 [[nodiscard]] MTPObject deserializeObject(std::vector<char> serialized);
@@ -17,5 +31,6 @@ template<typename MTPObject>
 std::pair<std::string, std::vector<char>> serializeTextWithEntities(not_null<HistoryItem*> item);
 [[nodiscard]] MTPVector<MTPMessageEntity> deserializeTextWithEntities(std::vector<char> serialized);
 int mapItemFlagsToMTPFlags(not_null<HistoryItem*> item);
+void mapMediaToMessage(not_null<HistoryItem*> item, AyuMessageBase &message);
 
 } // namespace AyuMapper


### PR DESCRIPTION
Deleted and edited messages with media previously stored only a text placeholder — media metadata was never serialized to the database and the history viewer always passed `MTP_messageMediaEmpty()` to `makeMessage()`.

This adds:
- `kDocumentType*` constants and `AyuMapper::mapMediaToMessage()` to serialize `MTPInputPhoto`/`MTPInputDocument` into `documentSerialized`;
- a `resolveMedia()` reconstruction in `GenerateItems()` that rebuilds `MTPPhoto`/`MTPDocument` with proper attributes (video, sticker, voice, audio, animated) so media renders correctly in the history viewer;
- saving media-only messages with a type placeholder instead of skipping them.

Supersedes #381 and #382, which bundled several unrelated changes. This branch is rebased on the latest `dev` and contains only the media-history change.

This PR was AI generated.
