### PR TITLE
fix: fix YUV420 chroma plane size tracking in OpenGL video renderer

### DIFF
--- a/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
@@ -274,6 +274,16 @@ void OverlayWidget::RendererGL::init(QOpenGLFunctions &f) {
 
 void OverlayWidget::RendererGL::deinit(QOpenGLFunctions *f) {
 	_textures.destroy(f);
+	for (auto i = 0; i != 3; ++i) {
+		_rgbaSize[i] = QSize();
+		_cacheKeys[i] = 0;
+	}
+	_lumaSize = QSize();
+	_chromaSize = QSize();
+	_chromaSizeV = QSize();
+	_chromaNV12 = false;
+	_trackFrameIndex = 0;
+	_streamedIndex = 0;
 	_imageProgram = std::nullopt;
 	_texturedVertexShader = nullptr;
 	_withTransparencyProgram = std::nullopt;
@@ -424,8 +434,8 @@ void OverlayWidget::RendererGL::paintTransformedVideoFrame(
 			nv12changed ? QSize() : _chromaSize,
 			yuv->u.stride / (nv12 ? 2 : 1),
 			yuv->u.data);
+		_chromaSize = yuv->chromaSize;
 		if (nv12) {
-			_chromaSize = yuv->chromaSize;
 			_f->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		}
 		_chromaNV12 = nv12;
@@ -443,10 +453,10 @@ void OverlayWidget::RendererGL::paintTransformedVideoFrame(
 				GL_ALPHA,
 				GL_ALPHA,
 				yuv->chromaSize,
-				_chromaSize,
+				_chromaSizeV,
 				yuv->v.stride,
 				yuv->v.data);
-			_chromaSize = yuv->chromaSize;
+			_chromaSizeV = yuv->chromaSize;
 			_f->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		}
 

--- a/Telegram/SourceFiles/media/view/media_view_overlay_opengl.h
+++ b/Telegram/SourceFiles/media/view/media_view_overlay_opengl.h
@@ -135,7 +135,8 @@ private:
 	Ui::GL::Textures<6> _textures; // image, sibling, right sibling, y, u, v
 	QSize _rgbaSize[3];
 	QSize _lumaSize;
-	QSize _chromaSize;
+	QSize _chromaSize; // size of texture 4 (UV for NV12, U for YUV420)
+	QSize _chromaSizeV; // size of texture 5 (V for YUV420 only)
 	qint64 _cacheKeys[3] = { 0 }; // image, sibling, right sibling
 	int _trackFrameIndex = 0;
 	int _streamedIndex = 0;

--- a/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp
+++ b/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp
@@ -238,6 +238,13 @@ void Pip::RendererGL::deinit(QOpenGLFunctions *f) {
 	_volumeControllerImage.destroy(f);
 	_shadowImage.destroy(f);
 	_textures.destroy(f);
+	_rgbaSize = QSize();
+	_lumaSize = QSize();
+	_chromaSize = QSize();
+	_chromaSizeV = QSize();
+	_chromaNV12 = false;
+	_trackFrameIndex = 0;
+	_cacheKey = 0;
 	_imageProgram = std::nullopt;
 	_texturedVertexShader = nullptr;
 	_argb32Program = std::nullopt;
@@ -337,8 +344,8 @@ void Pip::RendererGL::paintTransformedVideoFrame(
 			nv12changed ? QSize() : _chromaSize,
 			yuv->u.stride / (nv12 ? 2 : 1),
 			yuv->u.data);
+		_chromaSize = yuv->chromaSize;
 		if (nv12) {
-			_chromaSize = yuv->chromaSize;
 			_f->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		}
 		_chromaNV12 = nv12;
@@ -351,10 +358,10 @@ void Pip::RendererGL::paintTransformedVideoFrame(
 				GL_ALPHA,
 				GL_ALPHA,
 				yuv->chromaSize,
-				_chromaSize,
+				_chromaSizeV,
 				yuv->v.stride,
 				yuv->v.data);
-			_chromaSize = yuv->chromaSize;
+			_chromaSizeV = yuv->chromaSize;
 			_f->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 		}
 	}

--- a/Telegram/SourceFiles/media/view/media_view_pip_opengl.h
+++ b/Telegram/SourceFiles/media/view/media_view_pip_opengl.h
@@ -102,7 +102,8 @@ private:
 	Ui::GL::Textures<4> _textures;
 	QSize _rgbaSize;
 	QSize _lumaSize;
-	QSize _chromaSize;
+	QSize _chromaSize; // size of texture 2 (UV for NV12, U for YUV420)
+	QSize _chromaSizeV; // size of texture 3 (V for YUV420 only)
 	quint64 _cacheKey = 0;
 	int _trackFrameIndex = 0;
 	bool _chromaNV12 = false;


### PR DESCRIPTION
The `U` and `V` chroma planes shared a single `_chromaSize` field, so the size-change detection for one plane was compared against the other's size, causing incorrect `glTexImage`/`glTexSubImage` decisions (bad colors on macOS and potential redundant texture re-uploads).

Split the tracking into `_chromaSize` (UV for NV12 / U for YUV420) and `_chromaSizeV` (V for YUV420), and reset the renderer size state in `deinit()`. Cherry-picked from upstream 98a16c63eb.

This PR was AI generated.
