### PR TITLE
fix: reset DPR on scaled tray icon to fix counter misalignment at high DPI

### DIFF
--- a/Telegram/SourceFiles/platform/win/tray_win.cpp
+++ b/Telegram/SourceFiles/platform/win/tray_win.cpp
@@ -162,13 +162,12 @@ bool DarkTasbarValueValid/* = false*/;
 		} else if (monochrome && darkMode) {
 			return MonochromeIconFor(args.size, *darkMode);
 		}
-		return scaled.emplace(
-			args.size,
-			(smallIcon
-				? Window::LogoNoMargin()
-				: Window::Logo()
-			).scaledToWidth(args.size, Qt::SmoothTransformation)
-		).first->second;
+		auto img = (smallIcon
+			? Window::LogoNoMargin()
+			: Window::Logo()
+		).scaledToWidth(args.size, Qt::SmoothTransformation);
+		img.setDevicePixelRatio(1.0);
+		return scaled.emplace(args.size, std::move(img)).first->second;
 	}();
 	if ((!monochrome || !darkMode) && supportMode) {
 		Window::ConvertIconToBlack(result);


### PR DESCRIPTION
`AyuAssets::currentAppLogo()` sets `devicePixelRatio` to `style::DevicePixelRatio()` (e.g. 2.0 at 200% scaling). After `scaledToWidth()` Qt preserves that DPR, making the logical canvas smaller than `args.size` while `WithSmallCounter` uses `args.size` as drawing coordinates — so the counter badge renders partially outside bounds (visible as a grey triangle). Upstream loads the icon from PNG files (DPR = 1), so this mismatch only affects AyuGram.

Fixes #310.

This PR was AI generated.
