### PR TITLE
feat: add trusted chat exceptions to Ghost Mode

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -113,6 +113,7 @@ set(ayugram_files
         ayu/ayu_state.h
         ayu/ayu_settings.cpp
         ayu/ayu_settings.h
+        ayu/ghost_mode_peer_exceptions.h
         ayu/ayu_lang.cpp
         ayu/ayu_lang.h
         ayu/ayu_infra.cpp
@@ -909,6 +910,8 @@ PRIVATE
     data/data_types.h
     data/data_unread_value.cpp
     data/data_unread_value.h
+    data/data_unsent_read_generation.h
+    data/data_unsent_read_till.h
     data/data_user.cpp
     data/data_user.h
     data/data_user_photos.cpp

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -7985,6 +7985,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "ayu_CategoryCustomization" = "Customization";
 "ayu_GhostEssentialsHeader" = "Ghost essentials";
 "ayu_DontReadMessages" = "Don't Read Messages";
+"ayu_GhostAlwaysSendReadsAndActivity" = "Always Send Reads and Activity";
+"ayu_GhostUseDefaultsForTrustedChat" = "Use Ghost Mode Defaults";
 "ayu_DontReadStories" = "Don't Read Stories";
 "ayu_DontSendOnlinePackets" = "Don't Send Online";
 "ayu_DontSendUploadProgress" = "Don't Send Typing";

--- a/Telegram/SourceFiles/api/api_polls.cpp
+++ b/Telegram/SourceFiles/api/api_polls.cpp
@@ -187,8 +187,9 @@ void Polls::sendVotes(
 		_session->updates().applyUpdates(result);
 
 		const auto &ghost = AyuSettings::ghost(_session);
-		if (!ghost.sendReadMessages() && ghost.markReadAfterAction() && item)
-		{
+		if (item
+			&& !ghost.shouldSendReadMessages(item->history()->peer)
+			&& ghost.markReadAfterAction()) {
 			readHistory(item);
 		}
 	}).fail([=] {

--- a/Telegram/SourceFiles/api/api_send_progress.cpp
+++ b/Telegram/SourceFiles/api/api_send_progress.cpp
@@ -117,11 +117,9 @@ void SendProgressManager::send(const Key &key, int progress) {
 		return;
 	}
 
-	// AyuGram sendUploadProgress
 	const auto &ghost = AyuSettings::ghost(_session);
-	if (!ghost.sendUploadProgress())
-	{
-		DEBUG_LOG(("[AyuGram] Don't send upload progress"));
+	if (!ghost.shouldSendChatActivity(key.history->peer)) {
+		DEBUG_LOG(("[AyuGram] Don't send chat activity"));
 		return;
 	}
 

--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -1371,7 +1371,9 @@ void ApiWrap::markContentsRead(
 			continue;
 		}
 
-		if (!ghost.sendReadMessages() && !passthrough) {
+		if (!ghost.shouldSendReadMessages(
+				item->history()->peer,
+				passthrough)) {
 			continue;
 		}
 
@@ -1404,7 +1406,9 @@ void ApiWrap::markContentsRead(not_null<HistoryItem*> item) {
 	}
 
 	const auto &ghost = AyuSettings::ghost(&session());
-	if (!ghost.sendReadMessages() && !passthrough) {
+	if (!ghost.shouldSendReadMessages(
+			item->history()->peer,
+			passthrough)) {
 		return;
 	}
 

--- a/Telegram/SourceFiles/ayu/ayu_settings.cpp
+++ b/Telegram/SourceFiles/ayu/ayu_settings.cpp
@@ -12,6 +12,9 @@
 #include "ayu/ayu_worker.h"
 #include "ayu/ui/ayu_logo.h"
 #include "core/application.h"
+#include "data/data_peer.h"
+#include "data/data_peer_id.h"
+#include "data/data_user.h"
 #include "features/filters/filters_cache_controller.h"
 #include "features/translator/ayu_translator.h"
 #include "main/main_domain.h"
@@ -20,8 +23,11 @@
 #include "rpl/combine.h"
 #include "window/window_controller.h"
 
-#include <fstream>
 #include <QApplication>
+
+#include <algorithm>
+#include <fstream>
+#include <vector>
 
 using json = nlohmann::json;
 
@@ -38,6 +44,39 @@ void repaintApp() {
 }
 
 rpl::lifetime lifetime; // idk reactivity dies when placed in `GhostModeAccountSettings` as field
+
+using TrustedChatExceptions = Ayu::GhostModePeerExceptions;
+
+[[nodiscard]] auto SerializedTrustedChatPeerId(PeerId peerId)
+		-> std::optional<TrustedChatExceptions::SerializedPeerId> {
+	const auto userId = peerToUser(peerId);
+	if (!peerId || !userId || peerFromUser(userId) != peerId) {
+		return std::nullopt;
+	}
+	return SerializePeerId(peerFromUser(userId));
+}
+
+[[nodiscard]] auto SerializedTrustedChatPeerId(not_null<PeerData*> peer)
+		-> std::optional<TrustedChatExceptions::SerializedPeerId> {
+	const auto user = peer->asUser();
+	if (!user || user->isSelf() || user->isBot()) {
+		return std::nullopt;
+	}
+	return SerializedTrustedChatPeerId(peer->id);
+}
+
+[[nodiscard]] auto ValidTrustedChatExceptions(
+		TrustedChatExceptions::Values values) {
+	auto result = TrustedChatExceptions::Values();
+	result.reserve(values.size());
+	for (const auto serialized : values) {
+		const auto peerId = DeserializePeerId(serialized);
+		if (const auto normalized = SerializedTrustedChatPeerId(peerId)) {
+			result.emplace(*normalized);
+		}
+	}
+	return result;
+}
 
 } // namespace
 
@@ -67,9 +106,55 @@ GhostModeAccountSettings::GhostModeAccountSettings() {
 	}, lifetime);
 }
 
+bool GhostModeAccountSettings::shouldSendReadMessages(
+		not_null<PeerData*> peer,
+		bool passthrough) const {
+	return _trustedChatExceptions.shouldSend(
+		sendReadMessages() || passthrough,
+		SerializedTrustedChatPeerId(peer));
+}
+
+bool GhostModeAccountSettings::shouldSendChatActivity(
+		not_null<PeerData*> peer) const {
+	return _trustedChatExceptions.shouldSend(
+		sendUploadProgress(),
+		SerializedTrustedChatPeerId(peer));
+}
+
+bool GhostModeAccountSettings::isTrustedChatException(
+		not_null<PeerData*> peer) const {
+	const auto serialized = SerializedTrustedChatPeerId(peer);
+	return serialized && _trustedChatExceptions.contains(*serialized);
+}
+
+auto GhostModeAccountSettings::trustedChatExceptions() const
+		-> const Ayu::GhostModePeerExceptions::Values & {
+	return _trustedChatExceptions.values();
+}
+
 void GhostModeAccountSettings::setSendReadMessages(bool val) {
 	if (_sendReadMessages.current() == val) return;
 	_sendReadMessages = val;
+	AyuSettings::save();
+}
+
+void GhostModeAccountSettings::setTrustedChatException(
+		not_null<PeerData*> peer,
+		bool enabled) {
+	const auto serialized = SerializedTrustedChatPeerId(peer);
+	if (!serialized || !_trustedChatExceptions.set(*serialized, enabled)) {
+		return;
+	}
+	AyuSettings::save();
+}
+
+void GhostModeAccountSettings::setTrustedChatExceptions(
+		Ayu::GhostModePeerExceptions::Values values) {
+	values = ValidTrustedChatExceptions(std::move(values));
+	if (_trustedChatExceptions.values() == values) {
+		return;
+	}
+	_trustedChatExceptions.replace(std::move(values));
 	AyuSettings::save();
 }
 
@@ -182,8 +267,15 @@ void GhostModeAccountSettings::setSendOfflinePacketAfterOnlineLocked(bool val) {
 }
 
 void to_json(nlohmann::json &j, const GhostModeAccountSettings &s) {
+	auto trustedChatExceptions = std::vector<
+		Ayu::GhostModePeerExceptions::SerializedPeerId>(
+			s._trustedChatExceptions.values().begin(),
+			s._trustedChatExceptions.values().end());
+	std::sort(trustedChatExceptions.begin(), trustedChatExceptions.end());
+
 	j = nlohmann::json{
 		{"sendReadMessages", s._sendReadMessages.current()},
+		{"trustedChatExceptions", std::move(trustedChatExceptions)},
 		{"sendReadStories", s._sendReadStories.current()},
 		{"sendOnlinePackets", s._sendOnlinePackets.current()},
 		{"sendUploadProgress", s._sendUploadProgress.current()},
@@ -202,6 +294,30 @@ void to_json(nlohmann::json &j, const GhostModeAccountSettings &s) {
 
 void from_json(const nlohmann::json &j, GhostModeAccountSettings &s) {
 	s._sendReadMessages = j.value("sendReadMessages", true);
+	auto trustedChatExceptions = TrustedChatExceptions::Values();
+	const auto currentExceptions = j.find("trustedChatExceptions");
+	const auto legacyExceptions = j.find("readReceiptExceptions");
+	const auto exceptions = (currentExceptions != j.end()
+			&& currentExceptions->is_array())
+		? currentExceptions
+		: legacyExceptions;
+	if (exceptions != j.end() && exceptions->is_array()) {
+		for (const auto &value : *exceptions) {
+			if (value.is_number_unsigned()) {
+				trustedChatExceptions.emplace(
+					value.get<TrustedChatExceptions::SerializedPeerId>());
+			} else if (value.is_number_integer()) {
+				const auto serialized = value.get<std::int64_t>();
+				if (serialized >= 0) {
+					trustedChatExceptions.emplace(
+						static_cast<
+							TrustedChatExceptions::SerializedPeerId>(serialized));
+				}
+			}
+		}
+	}
+	s._trustedChatExceptions.replace(
+		ValidTrustedChatExceptions(std::move(trustedChatExceptions)));
 	s._sendReadStories = j.value("sendReadStories", true);
 	s._sendOnlinePackets = j.value("sendOnlinePackets", true);
 	s._sendUploadProgress = j.value("sendUploadProgress", true);

--- a/Telegram/SourceFiles/ayu/ayu_settings.h
+++ b/Telegram/SourceFiles/ayu/ayu_settings.h
@@ -6,6 +6,7 @@
 // Copyright @Radolyn, 2026
 #pragma once
 
+#include "ayu/ghost_mode_peer_exceptions.h"
 #include "ayu/libs/json.hpp"
 #include "ayu/libs/json_ext.hpp"
 #include "rpl/lifetime.h"
@@ -19,6 +20,8 @@
 namespace Main {
 class Session;
 }
+
+class PeerData;
 
 enum class PeerIdDisplay {
 	Hidden = 0,
@@ -87,6 +90,13 @@ public:
 	GhostModeAccountSettings();
 
 	[[nodiscard]] bool sendReadMessages() const { return _sendReadMessages.current(); }
+	[[nodiscard]] bool shouldSendReadMessages(
+		not_null<PeerData*> peer,
+		bool passthrough = false) const;
+	[[nodiscard]] bool shouldSendChatActivity(not_null<PeerData*> peer) const;
+	[[nodiscard]] bool isTrustedChatException(not_null<PeerData*> peer) const;
+	[[nodiscard]] auto trustedChatExceptions() const
+		-> const Ayu::GhostModePeerExceptions::Values &;
 	[[nodiscard]] bool sendReadStories() const { return _sendReadStories.current(); }
 	[[nodiscard]] bool sendOnlinePackets() const { return _sendOnlinePackets.current(); }
 	[[nodiscard]] bool sendUploadProgress() const { return _sendUploadProgress.current(); }
@@ -106,6 +116,8 @@ public:
 	[[nodiscard]] bool sendOfflinePacketAfterOnlineLocked() const { return _sendOfflinePacketAfterOnlineLocked.current(); }
 
 	void setSendReadMessages(bool val);
+	void setTrustedChatException(not_null<PeerData*> peer, bool enabled);
+	void setTrustedChatExceptions(Ayu::GhostModePeerExceptions::Values values);
 	void setSendReadStories(bool val);
 	void setSendOnlinePackets(bool val);
 	void setSendUploadProgress(bool val);
@@ -161,6 +173,7 @@ private:
 	friend class AyuSettings;
 
 	rpl::variable<bool> _sendReadMessages = true;
+	Ayu::GhostModePeerExceptions _trustedChatExceptions;
 	rpl::variable<bool> _sendReadStories = true;
 	rpl::variable<bool> _sendOnlinePackets = true;
 	rpl::variable<bool> _sendUploadProgress = true;

--- a/Telegram/SourceFiles/ayu/ghost_mode_peer_exceptions.h
+++ b/Telegram/SourceFiles/ayu/ghost_mode_peer_exceptions.h
@@ -1,0 +1,50 @@
+// This is the source code of AyuGram for Desktop.
+//
+// We do not and cannot prevent the use of our code,
+// but be respectful and credit the original author.
+//
+// Copyright @Radolyn, 2026
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+namespace Ayu {
+
+class GhostModePeerExceptions final {
+public:
+	using SerializedPeerId = std::uint64_t;
+	using Values = std::unordered_set<SerializedPeerId>;
+
+	[[nodiscard]] bool shouldSend(
+			bool globallyEnabled,
+			std::optional<SerializedPeerId> peerId) const {
+		return globallyEnabled || (peerId && contains(*peerId));
+	}
+
+	[[nodiscard]] bool contains(SerializedPeerId peerId) const {
+		return _values.contains(peerId);
+	}
+
+	bool set(SerializedPeerId peerId, bool enabled) {
+		return enabled
+			? _values.emplace(peerId).second
+			: (_values.erase(peerId) != 0);
+	}
+
+	[[nodiscard]] const Values &values() const {
+		return _values;
+	}
+
+	void replace(Values values) {
+		_values = std::move(values);
+	}
+
+private:
+	Values _values;
+
+};
+
+} // namespace Ayu

--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.cpp
@@ -210,6 +210,11 @@ Fn<void()> DeleteMyMessagesHandler(not_null<Window::SessionController*> controll
 	};
 }
 
+bool CanToggleGhostTrustedChatException(PeerData *peerData) {
+	const auto user = peerData ? peerData->asUser() : nullptr;
+	return user && !user->isSelf() && !user->isBot();
+}
+
 }
 
 bool needToShowItem(ContextMenuVisibility state) {
@@ -230,7 +235,9 @@ void AddAyuGramActions(PeerData *peerData,
 	const auto showFilters = settings.filtersEnabled()
 		&& (!user || user->isBot());
 	const auto saveDeletedMessages = settings.saveDeletedMessages();
-	if (!showFilters && !saveDeletedMessages) {
+	const auto showTrustedChatException = CanToggleGhostTrustedChatException(
+		peerData);
+	if (!showFilters && !saveDeletedMessages && !showTrustedChatException) {
 		return;
 	}
 
@@ -243,6 +250,12 @@ void AddAyuGramActions(PeerData *peerData,
 		.icon = &st::menuIconGroupReactions,
 		.fillSubmenu = [=](not_null<Ui::PopupMenu*> menu) {
 			const auto addAction = Ui::Menu::CreateAddActionCallback(menu);
+			if (showTrustedChatException) {
+				AddGhostTrustedChatExceptionAction(peerData, addAction);
+				if (showFilters || saveDeletedMessages) {
+					addAction({ .isSeparator = true });
+				}
+			}
 			if (showFilters) {
 				addAction(
 					tr::ayu_ViewFiltersMenuText(tr::now),
@@ -429,6 +442,29 @@ void AddShadowBanAction(PeerData *peerData,
 					 : tr::ayu_FiltersQuickShadowBan(tr::now)),
 		.handler = toggleShadowBan,
 		.icon = shadowBanned ? &st::menuIconShowInChat : &st::menuIconStealth,
+	});
+}
+
+void AddGhostTrustedChatExceptionAction(
+		PeerData *peerData,
+		const Window::PeerMenuCallback &addCallback) {
+	if (!CanToggleGhostTrustedChatException(peerData)) {
+		return;
+	}
+
+	const auto &ghost = AyuSettings::ghost(&peerData->session());
+	const auto trusted = ghost.isTrustedChatException(peerData);
+	addCallback({
+		.text = trusted
+			? tr::ayu_GhostUseDefaultsForTrustedChat(tr::now)
+			: tr::ayu_GhostAlwaysSendReadsAndActivity(tr::now),
+		.handler = [=] {
+			auto &current = AyuSettings::ghost(&peerData->session());
+			current.setTrustedChatException(
+				peerData,
+				!current.isTrustedChatException(peerData));
+		},
+		.icon = trusted ? &st::menuIconStealth : &st::menuIconMarkRead,
 	});
 }
 
@@ -863,7 +899,7 @@ void AddReadUntilAction(not_null<Ui::PopupMenu*> menu, HistoryItem *item) {
 	}
 
 	const auto &ghost = AyuSettings::ghost(&item->history()->session());
-	if (ghost.sendReadMessages()) {
+	if (ghost.shouldSendReadMessages(item->history()->peer)) {
 		return;
 	}
 

--- a/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.h
+++ b/Telegram/SourceFiles/ayu/ui/context_menu/context_menu.h
@@ -33,6 +33,9 @@ void AddJumpToBeginningAction(PeerData *peerData,
 
 void AddShadowBanAction(PeerData *peerData,
 						const Window::PeerMenuCallback &addCallback);
+void AddGhostTrustedChatExceptionAction(
+	PeerData *peerData,
+	const Window::PeerMenuCallback &addCallback);
 void AddOpenChannelAction(PeerData *peerData,
 						  not_null<Window::SessionController*> sessionController,
 						  const Window::PeerMenuCallback &addCallback);

--- a/Telegram/SourceFiles/ayu/ui/settings/settings_ayu.cpp
+++ b/Telegram/SourceFiles/ayu/ui/settings/settings_ayu.cpp
@@ -321,6 +321,7 @@ void BuildGhostEssentials(SectionBuilder &builder) {
 				auto &src = AyuSettings::ghost(userId);
 				auto &dst = AyuSettings::ghost(0);
 				dst.setSendReadMessages(src.sendReadMessages());
+				dst.setTrustedChatExceptions(src.trustedChatExceptions());
 				dst.setSendReadStories(src.sendReadStories());
 				dst.setSendOnlinePackets(src.sendOnlinePackets());
 				dst.setSendUploadProgress(src.sendUploadProgress());

--- a/Telegram/SourceFiles/ayu/utils/telegram_helpers.cpp
+++ b/Telegram/SourceFiles/ayu/utils/telegram_helpers.cpp
@@ -301,17 +301,23 @@ bool isMessageHidden(const not_null<HistoryItem*> item) {
 	return FiltersController::filtered(item);
 }
 
-void MarkAsReadChatList(not_null<Dialogs::MainList*> list) {
+void MarkAsReadChatList(
+		not_null<Dialogs::MainList*> list,
+		bool locally) {
 	auto mark = std::vector<not_null<History*>>();
 	for (const auto &row : list->indexed()->all()) {
 		if (const auto history = row->history()) {
 			mark.push_back(history);
 		}
 	}
-	ranges::for_each(mark, MarkAsReadThread);
+	for (const auto history : mark) {
+		MarkAsReadThread(history, locally);
+	}
 }
 
-void readMentions(base::weak_ptr<Data::Thread> weakThread) {
+void readMentions(
+		base::weak_ptr<Data::Thread> weakThread,
+		Data::UnsentReadGeneration::Generation generation) {
 	const auto thread = weakThread.get();
 	if (!thread) {
 		return;
@@ -330,14 +336,19 @@ void readMentions(base::weak_ptr<Data::Thread> weakThread) {
 			peer,
 			result);
 		if (offset > 0) {
-			readMentions(weakThread);
+			readMentions(weakThread, generation);
 		} else {
+			if (const auto current = weakThread.get()) {
+				current->unreadMentionsReadDebt().sent(generation);
+			}
 			peer->owner().history(peer)->clearUnreadMentionsFor(rootId);
 		}
 	}).send();
 }
 
-void readReactions(base::weak_ptr<Data::Thread> weakThread) {
+void readReactions(
+		base::weak_ptr<Data::Thread> weakThread,
+		Data::UnsentReadGeneration::Generation generation) {
 	const auto thread = weakThread.get();
 	if (!thread) {
 		return;
@@ -358,55 +369,99 @@ void readReactions(base::weak_ptr<Data::Thread> weakThread) {
 			peer,
 			result);
 		if (offset > 0) {
-			readReactions(weakThread);
+			readReactions(weakThread, generation);
 		} else {
+			if (const auto current = weakThread.get()) {
+				current->unreadReactionsReadDebt().sent(generation);
+			}
 			peer->owner().history(peer)->clearUnreadReactionsFor(rootId, sublist);
 		}
 	}).send();
 }
 
-void MarkAsReadThread(not_null<Data::Thread*> thread) {
-	const auto readHistoryNative = [&](const not_null<History*> history)
+void MarkAsReadThread(not_null<Data::Thread*> thread, bool locally) {
+	const auto readHistoryNative = [=](const not_null<History*> history)
 	{
-		history->owner().histories().readInbox(history);
+		if (locally) {
+			history->owner().histories().readInboxLocally(history);
+		} else {
+			history->owner().histories().readInbox(history);
+		}
 	};
 	const auto sendReadMentions = [=](
 		const not_null<Data::Thread*> threadInner)
 	{
-		readMentions(base::make_weak(threadInner));
+		readMentions(
+			base::make_weak(threadInner),
+			threadInner->unreadMentionsReadDebt().generation());
 	};
 	const auto sendReadReactions = [=](
 		const not_null<Data::Thread*> threadInner)
 	{
-		readReactions(base::make_weak(threadInner));
+		readReactions(
+			base::make_weak(threadInner),
+			threadInner->unreadReactionsReadDebt().generation());
+	};
+	const auto clearReadMentions = [](
+		const not_null<Data::Thread*> threadInner)
+	{
+		threadInner->unreadMentionsReadDebt().add();
+		const auto peer = threadInner->peer();
+		const auto topic = threadInner->asTopic();
+		peer->owner().history(peer)->clearUnreadMentionsFor(
+			topic ? topic->rootId() : MsgId());
+	};
+	const auto clearReadReactions = [](
+		const not_null<Data::Thread*> threadInner)
+	{
+		threadInner->unreadReactionsReadDebt().add();
+		const auto peer = threadInner->peer();
+		const auto topic = threadInner->asTopic();
+		peer->owner().history(peer)->clearUnreadReactionsFor(
+			topic ? topic->rootId() : MsgId(),
+			threadInner->asSublist());
 	};
 
-	if (thread->chatListBadgesState().unread) {
-		if (const auto forum = thread->asForum()) {
-			forum->enumerateTopics([](
-				not_null<Data::ForumTopic*> topic)
-				{
-					MarkAsReadThread(topic);
-				});
-		} else if (const auto topic = thread->asTopic()) {
+	if (const auto forum = thread->asForum()) {
+		forum->enumerateTopics([=](
+			not_null<Data::ForumTopic*> topic)
+			{
+				MarkAsReadThread(topic, locally);
+			});
+	} else if (const auto topic = thread->asTopic()) {
+		if (locally) {
+			topic->readTillEndLocally();
+		} else {
 			topic->readTillEnd();
-		} else if (const auto history = thread->asHistory()) {
-			readHistoryNative(history);
-			if (const auto migrated = history->migrateSibling()) {
-				readHistoryNative(migrated);
-			}
+		}
+	} else if (const auto history = thread->asHistory()) {
+		readHistoryNative(history);
+		if (const auto migrated = history->migrateSibling()) {
+			readHistoryNative(migrated);
 		}
 	}
 
-	if (thread->unreadMentions().has()) {
-		sendReadMentions(thread);
+	if (thread->unreadMentions().has()
+		|| thread->unreadMentionsReadDebt()) {
+		if (locally) {
+			clearReadMentions(thread);
+		} else {
+			sendReadMentions(thread);
+		}
 	}
 
-	if (thread->unreadReactions().has()) {
-		sendReadReactions(thread);
+	if (thread->unreadReactions().has()
+		|| thread->unreadReactionsReadDebt()) {
+		if (locally) {
+			clearReadReactions(thread);
+		} else {
+			sendReadReactions(thread);
+		}
 	}
 
-	AyuWorker::markAsOnline(&thread->session());
+	if (!locally) {
+		AyuWorker::markAsOnline(&thread->session());
+	}
 }
 
 void readHistory(not_null<HistoryItem*> message) {
@@ -437,18 +492,25 @@ void readHistory(not_null<HistoryItem*> message) {
 						 }).send();
 					 });
 
-	if (history->unreadMentions().has()) {
-		readMentions(history->asThread());
+	if (history->unreadMentions().has()
+		|| history->unreadMentionsReadDebt()) {
+		readMentions(
+			history->asThread(),
+			history->unreadMentionsReadDebt().generation());
 	}
 
-	if (history->unreadReactions().has()) {
-		readReactions(history->asThread());
+	if (history->unreadReactions().has()
+		|| history->unreadReactionsReadDebt()) {
+		readReactions(
+			history->asThread(),
+			history->unreadReactionsReadDebt().generation());
 	}
 }
 
 void markReadAfterAction(not_null<History*> history) {
 	const auto &ghost = AyuSettings::ghost(&history->session());
-	if (ghost.sendReadMessages() || !ghost.markReadAfterAction()) {
+	if (ghost.shouldSendReadMessages(history->peer)
+		|| !ghost.markReadAfterAction()) {
 		return;
 	}
 	if (const auto last = history->lastServerMessage()) {

--- a/Telegram/SourceFiles/ayu/utils/telegram_helpers.h
+++ b/Telegram/SourceFiles/ayu/utils/telegram_helpers.h
@@ -70,8 +70,10 @@ Fn<void()> badgeClickHandler(not_null<PeerData *> peer);
 
 bool isMessageHidden(not_null<HistoryItem*> item);
 
-void MarkAsReadChatList(not_null<Dialogs::MainList*> list);
-void MarkAsReadThread(not_null<Data::Thread*> thread);
+void MarkAsReadChatList(
+	not_null<Dialogs::MainList*> list,
+	bool locally = false);
+void MarkAsReadThread(not_null<Data::Thread*> thread, bool locally = false);
 
 void markReadAfterAction(not_null<History*> history);
 void readHistory(not_null<HistoryItem*> message);

--- a/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp
+++ b/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp
@@ -7,6 +7,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "chat_helpers/emoji_interactions.h"
 
+#include "ayu/ayu_settings.h"
 #include "chat_helpers/stickers_emoji_pack.h"
 #include "history/history_item.h"
 #include "history/history.h"
@@ -278,6 +279,11 @@ void EmojiInteractions::sendAccumulatedOutgoing(
 		return;
 	}
 	const auto peer = item->history()->peer;
+	const auto &ghost = AyuSettings::ghost(_session);
+	if (!ghost.shouldSendChatActivity(peer)) {
+		animations.erase(from, till);
+		return;
+	}
 	const auto emoji = from->emoji;
 	const auto requestId = _session->api().request(MTPmessages_SetTyping(
 		MTP_flags(0),
@@ -418,6 +424,10 @@ void EmojiInteractions::setWaitingForDownload(bool waiting) {
 }
 
 void EmojiInteractions::playStarted(not_null<PeerData*> peer, QString emoji) {
+	const auto &ghost = AyuSettings::ghost(_session);
+	if (!ghost.shouldSendChatActivity(peer)) {
+		return;
+	}
 	auto &map = _playStarted[peer];
 	const auto i = map.find(emoji);
 	const auto now = crl::now();

--- a/Telegram/SourceFiles/data/data_forum_topic.cpp
+++ b/Telegram/SourceFiles/data/data_forum_topic.cpp
@@ -390,6 +390,10 @@ void ForumTopic::readTillEnd() {
 	_replies->readTill(_lastKnownServerMessageId);
 }
 
+void ForumTopic::readTillEndLocally() {
+	_replies->readTillLocally(_lastKnownServerMessageId);
+}
+
 void ForumTopic::applyTopic(const MTPDforumTopic &data) {
 	Expects(_rootId == data.vid().v);
 

--- a/Telegram/SourceFiles/data/data_forum_topic.h
+++ b/Telegram/SourceFiles/data/data_forum_topic.h
@@ -121,6 +121,7 @@ public:
 
 	void setRealRootId(MsgId realId);
 	void readTillEnd();
+	void readTillEndLocally();
 	void requestChatListMessage();
 
 	void applyTopic(const MTPDforumTopic &data);

--- a/Telegram/SourceFiles/data/data_histories.cpp
+++ b/Telegram/SourceFiles/data/data_histories.cpp
@@ -178,22 +178,31 @@ void Histories::clearAll() {
 }
 
 void Histories::readInbox(not_null<History*> history) {
+	readInbox(history, false);
+}
+
+void Histories::readInboxLocally(not_null<History*> history) {
+	cancelPendingReadInbox(history);
+	readInbox(history, true);
+}
+
+void Histories::readInbox(not_null<History*> history, bool locally) {
 	DEBUG_LOG(("Reading: readInbox called."));
 	if (history->lastServerMessageKnown()) {
 		const auto last = history->lastServerMessage();
 		DEBUG_LOG(("Reading: last known, reading till %1."
 			).arg(last ? last->id.bare : 0));
-		readInboxTill(history, last ? last->id : 0);
+		readInboxTill(history, last ? last->id : 0, false, locally);
 		return;
 	} else if (history->loadedAtBottom()) {
 		if (const auto lastId = history->maxMsgId()) {
 			DEBUG_LOG(("Reading: loaded at bottom, maxMsgId %1."
 				).arg(lastId.bare));
-			readInboxTill(history, lastId);
+			readInboxTill(history, lastId, false, locally);
 			return;
 		} else if (history->loadedAtTop()) {
 			DEBUG_LOG(("Reading: loaded at bottom, loaded at top."));
-			readInboxTill(history, 0);
+			readInboxTill(history, 0, false, locally);
 			return;
 		}
 		DEBUG_LOG(("Reading: loaded at bottom, but requesting entry."));
@@ -204,7 +213,7 @@ void Histories::readInbox(not_null<History*> history) {
 		const auto last = history->lastServerMessage();
 		DEBUG_LOG(("Reading: got entry, reading till %1."
 			).arg(last ? last->id.bare : 0));
-		readInboxTill(history, last ? last->id : 0);
+		readInboxTill(history, last ? last->id : 0, false, locally);
 	});
 }
 
@@ -247,13 +256,14 @@ void Histories::readInboxTill(not_null<HistoryItem*> item) {
 }
 
 void Histories::readInboxTill(not_null<History*> history, MsgId tillId) {
-	readInboxTill(history, tillId, false);
+	readInboxTill(history, tillId, false, false);
 }
 
 void Histories::readInboxTill(
 		not_null<History*> history,
 		MsgId tillId,
-		bool force) {
+		bool force,
+		bool locally) {
 	Expects(IsServerMsgId(tillId) || (!tillId && !force));
 
 	DEBUG_LOG(("Reading: readInboxTill %1, force %2."
@@ -276,23 +286,69 @@ void Histories::readInboxTill(
 			}
 		}
 	});
+	const auto stateCleanup = gsl::finally([&] {
+		checkEmptyState(history);
+	});
 
 	Core::App().notifications().clearIncomingFromHistory(history);
+	if (locally) {
+		auto state = lookup(history);
+		if (history->unreadMark()) {
+			auto &current = state ? *state : _states[history];
+			current.unreadMarkNotSent.add();
+			state = &current;
+		}
+		history->setUnreadMark(false);
+		if (!IsServerMsgId(tillId) || !history->trackUnreadMessages()) {
+			history->updateChatListEntry();
+			return;
+		}
+		if (history->inboxReadTillId() < tillId) {
+			auto &current = state ? *state : _states[history];
+			current.readTillNotSent.add(tillId);
+		}
+		const auto stillUnread = history->countStillUnreadLocal(tillId);
+		history->setInboxReadTill(tillId);
+		if (stillUnread) {
+			history->setUnreadCount(*stillUnread);
+		}
+		history->updateChatListEntry();
+		return;
+	}
 
-	const auto needsRequest = history->readInboxTillNeedsRequest(tillId);
-	if (!needsRequest && !force) {
+	const auto maybeState = lookup(history);
+	if (maybeState
+			&& maybeState->unreadMarkNotSent
+			&& AyuSettings::ghost(&_owner->session())
+				.shouldSendReadMessages(history->peer)) {
+		const auto generation = maybeState->unreadMarkNotSent.generation();
+		changeDialogUnreadMark(history, false, [=](bool success) {
+			if (const auto state = lookup(history)) {
+				if (success) {
+					state->unreadMarkNotSent.sent(generation);
+				}
+				checkEmptyState(history);
+			}
+		});
+	}
+	const auto hasReadTillNotSent = maybeState
+		&& static_cast<bool>(maybeState->readTillNotSent);
+	const auto readTill = maybeState
+		? maybeState->readTillNotSent.with(tillId)
+		: tillId;
+	const auto needsRequest = history->readInboxTillNeedsRequest(readTill);
+	if (!needsRequest && !hasReadTillNotSent && !force) {
 		DEBUG_LOG(("Reading: readInboxTill finish 1."));
 		return;
 	} else if (!history->trackUnreadMessages()) {
 		DEBUG_LOG(("Reading: readInboxTill finish 2."));
 		return;
 	}
-	const auto maybeState = lookup(history);
-	if (maybeState && maybeState->sentReadTill >= tillId) {
+	if (maybeState && maybeState->sentReadTill >= readTill) {
 		DEBUG_LOG(("Reading: readInboxTill finish 3 with %1."
 			).arg(maybeState->sentReadTill.bare));
 		return;
-	} else if (maybeState && maybeState->willReadTill >= tillId) {
+	} else if (maybeState && maybeState->willReadTill >= readTill) {
 		DEBUG_LOG(("Reading: readInboxTill finish 4 with %1 and force %2."
 			).arg(maybeState->sentReadTill.bare
 			).arg(Logs::b(force)));
@@ -301,24 +357,26 @@ void Histories::readInboxTill(
 		}
 		return;
 	} else if (!needsRequest
+		&& !hasReadTillNotSent
 		&& (!maybeState || !maybeState->willReadTill)) {
 		return;
 	}
-	const auto stillUnread = history->countStillUnreadLocal(tillId);
+	const auto stillUnread = history->countStillUnreadLocal(readTill);
 	if (!force
+		&& !hasReadTillNotSent
 		&& stillUnread
 		&& history->unreadCountKnown()
 		&& *stillUnread == history->unreadCount()) {
 		DEBUG_LOG(("Reading: count didn't change so just update till %1"
-			).arg(tillId.bare));
-		history->setInboxReadTill(tillId);
+			).arg(readTill.bare));
+		history->setInboxReadTill(readTill);
 		return;
 	}
 	auto &state = maybeState ? *maybeState : _states[history];
-	state.willReadTill = tillId;
+	state.willReadTill = readTill;
 	if (force || !stillUnread || !*stillUnread) {
 		DEBUG_LOG(("Reading: will read till %1 with still unread %2"
-			).arg(tillId.bare
+			).arg(readTill.bare
 			).arg(stillUnread.value_or(-666)));
 		state.willReadWhen = 0;
 		sendReadRequests();
@@ -327,19 +385,19 @@ void Histories::readInboxTill(
 		}
 	} else if (!state.willReadWhen) {
 		DEBUG_LOG(("Reading: will read till %1 with postponed"
-			).arg(tillId.bare));
+			).arg(readTill.bare));
 		state.willReadWhen = crl::now() + kReadRequestTimeout;
 		if (!_readRequestsTimer.isActive()) {
 			_readRequestsTimer.callOnce(kReadRequestTimeout);
 		}
 	} else {
 		DEBUG_LOG(("Reading: will read till %1 postponed already"
-			).arg(tillId.bare));
+			).arg(readTill.bare));
 	}
 	DEBUG_LOG(("Reading: marking now with till %1 and still %2"
-		).arg(tillId.bare
+		).arg(readTill.bare
 		).arg(*stillUnread));
-	history->setInboxReadTill(tillId);
+	history->setInboxReadTill(readTill);
 	history->setUnreadCount(*stillUnread);
 	history->updateChatListEntry();
 }
@@ -348,7 +406,7 @@ void Histories::readInboxOnNewMessage(not_null<HistoryItem*> item) {
 	if (!item->isRegular()) {
 		readClientSideMessage(item);
 	} else {
-		readInboxTill(item->history(), item->id, true);
+		readInboxTill(item->history(), item->id, true, false);
 	}
 }
 
@@ -506,15 +564,25 @@ void Histories::applyPeerDialogs(const MTPmessages_PeerDialogs &dialogs) {
 
 void Histories::changeDialogUnreadMark(
 		not_null<History*> history,
-		bool unread) {
+		bool unread,
+		Fn<void(bool)> finished) {
 	history->setUnreadMark(unread);
 
 	using Flag = MTPmessages_MarkDialogUnread::Flag;
-	session().api().request(MTPmessages_MarkDialogUnread(
+	auto request = session().api().request(MTPmessages_MarkDialogUnread(
 		MTP_flags(unread ? Flag::f_unread : Flag(0)),
 		MTPInputPeer(), // parent_peer
 		MTP_inputDialogPeer(history->peer->input())
-	)).send();
+	));
+	if (finished) {
+		request.done([=] {
+			finished(true);
+		}).fail([=] {
+			finished(false);
+		}).send();
+	} else {
+		request.send();
+	}
 }
 
 void Histories::changeSublistUnreadMark(
@@ -624,6 +692,41 @@ void Histories::sendPendingReadInbox(not_null<History*> history) {
 	}
 }
 
+void Histories::cancelPendingReadInbox(not_null<History*> history) {
+	const auto state = lookup(history);
+	if (!state || (!state->willReadTill && !state->willReadWhen)) {
+		return;
+	}
+	DEBUG_LOG(("Reading: cancel pending local read with till %1 and when %2"
+		).arg(state->willReadTill.bare
+		).arg(state->willReadWhen));
+	state->readTillNotSent.add(state->willReadTill);
+	state->willReadTill = 0;
+	state->willReadWhen = 0;
+	checkEmptyState(history);
+	scheduleReadRequests();
+}
+
+void Histories::scheduleReadRequests() {
+	const auto now = crl::now();
+	auto next = std::optional<crl::time>();
+	for (const auto &entry : _states) {
+		const auto &state = entry.second;
+		if (!state.willReadTill) {
+			continue;
+		}
+		const auto when = state.willReadWhen;
+		if (!next || *next > when) {
+			next = when;
+		}
+	}
+	if (next.has_value()) {
+		_readRequestsTimer.callOnce(std::max(*next - now, crl::time(0)));
+	} else {
+		_readRequestsTimer.cancel();
+	}
+}
+
 void Histories::reportDelivery(not_null<HistoryItem*> item) {
 	auto &set = _pendingDeliveryReport[item->history()->peer];
 	if (!set.emplace(item->id).second) {
@@ -679,21 +782,23 @@ void Histories::reportPendingDeliveries() {
 void Histories::sendReadRequests() {
 	DEBUG_LOG(("Reading: send requests with count %1.").arg(_states.size()));
 
-	// AyuGram sendReadMessages
-	const auto &ghost = AyuSettings::ghost(&_owner->session());
-	if (!ghost.sendReadMessages()) {
-		DEBUG_LOG(("[AyuGram] Don't read messages"));
-		_states.clear();
-		return;
-	}
-
 	if (_states.empty()) {
 		return;
 	}
+	const auto &ghost = AyuSettings::ghost(&_owner->session());
 	const auto now = crl::now();
 	auto next = std::optional<crl::time>();
+	auto blocked = std::vector<not_null<History*>>();
 	for (auto &[history, state] : _states) {
-		if (!state.willReadTill) {
+		if (!ghost.shouldSendReadMessages(history->peer)) {
+			if (state.willReadTill) {
+				DEBUG_LOG(("[AyuGram] Don't read messages in this chat"));
+				state.readTillNotSent.add(state.willReadTill);
+			}
+			state.willReadTill = 0;
+			state.willReadWhen = 0;
+			blocked.push_back(history);
+		} else if (!state.willReadTill) {
 			DEBUG_LOG(("Reading: skipping zero till."));
 			continue;
 		} else if (state.willReadWhen <= now) {
@@ -704,6 +809,9 @@ void Histories::sendReadRequests() {
 			DEBUG_LOG(("Reading: scheduling for later send."));
 			next = state.willReadWhen;
 		}
+	}
+	for (const auto history : blocked) {
+		checkEmptyState(history);
 	}
 	if (next.has_value()) {
 		_readRequestsTimer.callOnce(*next - now);
@@ -723,16 +831,23 @@ void Histories::sendReadRequest(not_null<History*> history, State &state) {
 	sendRequest(history, RequestType::ReadInbox, [=](Fn<void()> finish) {
 		DEBUG_LOG(("Reading: sending request invoked with till %1."
 			).arg(tillId.bare));
-		const auto finished = [=] {
+		const auto finished = [=](bool success) {
 			auto state = lookup(history);
 			if (state == nullptr) {
 				// don’t care + didn’t ask + cry about it + who asked + stay mad + get real + L + bleed + mald seethe cope harder + dilate + incorrect + hoes mad + pound sand + basic skill issue + typo + ratio + ur dad left + you fell off + no u + the audacity + triggered + repelled + ur a minor + k. + any askers + get a life + ok and? + cringe + copium + go outside + touch grass + kick rocks + quote tweet + think again + not based + not funny didn’t laugh + social credits -999, 999, 999, 999 + get good + reported + ad hominem + ok boomer + small pp + ur allergic to sunlight + GG! + get rekt + trolled + your loss + muted + banned + kicked + permaban + useless + i slept with ur mom + yo momma + yo momma so fat + redpilled + no bitches allowed + i said it better + tiktok fan + get a life + unsubscribed + plundered + go tell reddit + donowalled + simp + get sticked bug LOL + talk nonsense + trump supporter + your’re a full time discord mod + you’re* + grammar issue + nerd + get clapped + kys + lorem ipsum dolor sit amet + go outside + bleach + lol + gay + retard + autistic + reported + ask deez + ez clap + straight cash + idgaf + ratio again + stay mad + read FAQ + youre lost + you “re” + stay pressed + reverse double take back + pedophile + cancelled + done for + don't give a damn + get a job + sus + baka + sussy baka + get blocked + mad free + freer than air + furry + rip bozo + you're a (insert stereotype) + slight_smile + aired + cringe again + Super Idol的笑容 + mad cuz bad + my pronouns are xe, xem & xyr + irrelevant + deal with it + screencapped your bio + karen/kyle + jealous + you're deaf + balls + i'll be right back + go ahead whine about it + not straight + eat paper + you lose + count to three + your problem + no one cares + log off + don't care even more + sex offender + sex defender + get religion + not okay + glhf + NFT owner + you make bad memes + problematic + fall in line + dog water + you look like a wall + you don’t know 2 + 2 with yo head ass + you are going to my cringe compilation + you can’t count to five + try again + you failed kindergarten + rickrolled + no lifer + guten freunden schickt man einen deutschen panzer + you have a anime profile picture + an* + fatherless + motherless + sisterless + brotherless + orphan + you can't catch this ratio + catch some bitches + I don't care about your opinion + genshin player + you dress like garbage + 日本語がお上手ですね + get fucked + you can’t understand what the word intelligence means with your dumb ass + you have hair + queued + put some thought into what you're going to do with that + stfu + go to bed + yes, i'm taller than you + i think your joke is funny + i rejected your mother's advances + marooned + you can’t read + I win + final ratio
 				state = &_states[history];
 			}
+			if (success) {
+				state->readTillNotSent.sent(tillId);
+			} else {
+				state->readTillNotSent.add(tillId);
+			}
 
 			if (state->sentReadTill == tillId) {
-				state->sentReadDone = true;
-				if (history->unreadCountRefreshNeeded(tillId)) {
+				state->sentReadDone = success;
+				if (!success) {
+					state->sentReadTill = 0;
+				} else if (history->unreadCountRefreshNeeded(tillId)) {
 					requestDialogEntry(history);
 				} else {
 					state->sentReadTill = 0;
@@ -740,7 +855,9 @@ void Histories::sendReadRequest(not_null<History*> history, State &state) {
 			} else {
 				Assert(!state->sentReadTill || state->sentReadTill > tillId);
 			}
-			history->validateMonoAndForumUnread(tillId);
+			if (success) {
+				history->validateMonoAndForumUnread(tillId);
+			}
 			sendReadRequests();
 			finish();
 		};
@@ -748,16 +865,20 @@ void Histories::sendReadRequest(not_null<History*> history, State &state) {
 			return session().api().request(MTPchannels_ReadHistory(
 				channel->inputChannel(),
 				MTP_int(tillId)
-			)).done(finished).fail(finished).send();
+			)).done([=] {
+				finished(true);
+			}).fail([=] {
+				finished(false);
+			}).send();
 		} else {
 			return session().api().request(MTPmessages_ReadHistory(
 				history->peer->input(),
 				MTP_int(tillId)
 			)).done([=](const MTPmessages_AffectedMessages &result) {
 				session().api().applyAffectedMessages(history->peer, result);
-				finished();
+				finished(true);
 			}).fail([=] {
-				finished();
+				finished(false);
 			}).send();
 		}
 	});
@@ -769,7 +890,9 @@ void Histories::checkEmptyState(not_null<History*> history) {
 			&& !state.postponedRequestEntry
 			&& state.sent.empty()
 			&& (state.willReadTill == 0)
-			&& (state.sentReadTill == 0);
+			&& (state.sentReadTill == 0)
+			&& !state.readTillNotSent
+			&& !state.unreadMarkNotSent;
 	};
 	const auto i = _states.find(history);
 	if (i != end(_states) && empty(i->second)) {

--- a/Telegram/SourceFiles/data/data_histories.h
+++ b/Telegram/SourceFiles/data/data_histories.h
@@ -8,6 +8,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "base/timer.h"
+#include "data/data_unsent_read_generation.h"
+#include "data/data_unsent_read_till.h"
 
 class History;
 class HistoryItem;
@@ -59,6 +61,7 @@ public:
 	void clearAll();
 
 	void readInbox(not_null<History*> history);
+	void readInboxLocally(not_null<History*> history);
 	void readInboxTill(not_null<HistoryItem*> item);
 	void readInboxTill(not_null<History*> history, MsgId tillId);
 	void readInboxOnNewMessage(not_null<HistoryItem*> item);
@@ -71,7 +74,10 @@ public:
 		not_null<History*> history,
 		Fn<void()> callback = nullptr);
 	void dialogEntryApplied(not_null<History*> history);
-	void changeDialogUnreadMark(not_null<History*> history, bool unread);
+	void changeDialogUnreadMark(
+		not_null<History*> history,
+		bool unread,
+		Fn<void(bool)> finished = nullptr);
 	void changeSublistUnreadMark(
 		not_null<Data::SavedSublist*> sublist,
 		bool unread);
@@ -155,7 +161,9 @@ private:
 		base::flat_map<int, SentRequest> sent;
 		MsgId willReadTill = 0;
 		MsgId sentReadTill = 0;
+		UnsentReadTill<MsgId> readTillNotSent;
 		crl::time willReadWhen = 0;
+		UnsentReadGeneration unreadMarkNotSent;
 		bool sentReadDone = false;
 		bool postponedRequestEntry = false;
 	};
@@ -192,7 +200,14 @@ private:
 		}
 	}
 
-	void readInboxTill(not_null<History*> history, MsgId tillId, bool force);
+	void readInbox(not_null<History*> history, bool locally);
+	void readInboxTill(
+		not_null<History*> history,
+		MsgId tillId,
+		bool force,
+		bool locally);
+	void cancelPendingReadInbox(not_null<History*> history);
+	void scheduleReadRequests();
 	void sendReadRequests();
 	void sendReadRequest(not_null<History*> history, State &state);
 	[[nodiscard]] State *lookup(not_null<History*> history);

--- a/Telegram/SourceFiles/data/data_message_reactions.cpp
+++ b/Telegram/SourceFiles/data/data_message_reactions.cpp
@@ -1522,7 +1522,9 @@ void Reactions::send(not_null<HistoryItem*> item, bool addToRecent) {
 		_owner->session().api().applyUpdates(result);
 
 		const auto &ghost = AyuSettings::ghost(&_owner->session());
-		if (!ghost.sendReadMessages() && ghost.markReadAfterAction() && item) {
+		if (item
+			&& !ghost.shouldSendReadMessages(item->history()->peer)
+			&& ghost.markReadAfterAction()) {
 			readHistory(item);
 		}
 	}).fail([=](const MTP::Error &error) {

--- a/Telegram/SourceFiles/data/data_replies_list.cpp
+++ b/Telegram/SourceFiles/data/data_replies_list.cpp
@@ -963,27 +963,50 @@ void RepliesList::requestUnreadCount() {
 }
 
 void RepliesList::readTill(not_null<HistoryItem*> item) {
-	readTill(item->id, item);
+	readTill(item->id, item, false);
 }
 
 void RepliesList::readTill(MsgId tillId) {
-	readTill(tillId, _history->owner().message(_history->peer->id, tillId));
+	readTill(
+		tillId,
+		_history->owner().message(_history->peer->id, tillId),
+		false);
+}
+
+void RepliesList::readTillLocally(MsgId tillId) {
+	readTill(
+		tillId,
+		_history->owner().message(_history->peer->id, tillId),
+		true);
 }
 
 void RepliesList::readTill(
 		MsgId tillId,
-		HistoryItem *tillIdItem) {
+		HistoryItem *tillIdItem,
+		bool locally) {
+	const auto hadPendingRequest = _readRequestTimer.isActive();
+	if (locally) {
+		_readRequestTimer.cancel();
+	}
 	if (!IsServerMsgId(tillId)) {
 		return;
 	}
 	const auto was = computeInboxReadTillFull();
-	const auto now = tillId;
+	if (locally && hadPendingRequest) {
+		_readTillNotSent.add(was);
+	}
+	const auto hadReadTillNotSent = static_cast<bool>(_readTillNotSent);
+	const auto requested = _readTillNotSent.with(tillId);
+	const auto now = hadReadTillNotSent ? std::max(was, requested) : requested;
 	if (now < was) {
 		return;
 	}
+	if (locally && now > was) {
+		_readTillNotSent.add(now);
+	}
 	const auto unreadCount = computeUnreadCountLocally(now);
 	const auto fast = (tillIdItem && tillIdItem->out()) || !unreadCount.has_value();
-	if (was < now || (fast && now == was)) {
+	if (hadReadTillNotSent || was < now || (fast && now == was)) {
 		setInboxReadTill(now, unreadCount);
 		const auto rootFullId = FullMsgId(_history->peer->id, _rootId);
 		if (const auto root = _history->owner().message(rootFullId)) {
@@ -991,10 +1014,14 @@ void RepliesList::readTill(
 				post->setCommentsInboxReadTill(now);
 			}
 		}
-		if (!_readRequestTimer.isActive()) {
-			_readRequestTimer.callOnce(fast ? 0 : kReadRequestTimeout);
-		} else if (fast && _readRequestTimer.remainingTime() > 0) {
-			_readRequestTimer.callOnce(0);
+		if (!locally) {
+			if (hadReadTillNotSent) {
+				_readRequestTimer.callOnce(0);
+			} else if (!_readRequestTimer.isActive()) {
+				_readRequestTimer.callOnce(fast ? 0 : kReadRequestTimeout);
+			} else if (fast && _readRequestTimer.remainingTime() > 0) {
+				_readRequestTimer.callOnce(0);
+			}
 		}
 	}
 	if (const auto topic = _history->peer->forumTopicFor(_rootId)) {
@@ -1009,18 +1036,24 @@ void RepliesList::sendReadTillRequest() {
 	const auto api = &_history->session().api();
 	api->request(base::take(_readRequestId)).cancel();
 
+	const auto readTill = computeInboxReadTillFull();
 	const auto &ghost = AyuSettings::ghost(&_history->session());
 	if (!ghost.sendReadMessages()) {
+		_readTillNotSent.add(readTill);
 		return;
 	}
 
 	_readRequestId = api->request(MTPmessages_ReadDiscussion(
 		_history->peer->input(),
 		MTP_int(_rootId),
-		MTP_int(computeInboxReadTillFull())
+		MTP_int(readTill)
 	)).done(crl::guard(this, [=] {
+		_readTillNotSent.sent(readTill);
 		_readRequestId = 0;
 		reloadUnreadCountIfNeeded();
+	})).fail(crl::guard(this, [=] {
+		_readTillNotSent.add(readTill);
+		_readRequestId = 0;
 	})).send();
 }
 

--- a/Telegram/SourceFiles/data/data_replies_list.h
+++ b/Telegram/SourceFiles/data/data_replies_list.h
@@ -7,8 +7,9 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #pragma once
 
-#include "base/weak_ptr.h"
 #include "base/timer.h"
+#include "base/weak_ptr.h"
+#include "data/data_unsent_read_till.h"
 
 class History;
 
@@ -62,6 +63,7 @@ public:
 
 	void readTill(not_null<HistoryItem*> item);
 	void readTill(MsgId tillId);
+	void readTillLocally(MsgId tillId);
 
 	[[nodiscard]] bool canDeleteMyTopic() const;
 
@@ -98,7 +100,7 @@ private:
 
 	void changeUnreadCountByPost(MsgId id, int delta);
 	void setUnreadCount(std::optional<int> count);
-	void readTill(MsgId tillId, HistoryItem *tillIdItem);
+	void readTill(MsgId tillId, HistoryItem *tillIdItem, bool locally);
 	void checkReadTillEnd();
 	void sendReadTillRequest();
 	void reloadUnreadCountIfNeeded();
@@ -125,6 +127,7 @@ private:
 
 	base::Timer _readRequestTimer;
 	mtpRequestId _readRequestId = 0;
+	UnsentReadTill<MsgId> _readTillNotSent;
 
 	mtpRequestId _reloadUnreadCountRequestId = 0;
 

--- a/Telegram/SourceFiles/data/data_thread.cpp
+++ b/Telegram/SourceFiles/data/data_thread.cpp
@@ -98,6 +98,14 @@ HistoryUnreadThings::ConstProxy Thread::unreadReactions() const {
 	};
 }
 
+UnsentReadGeneration &Thread::unreadMentionsReadDebt() {
+	return _unreadMentionsReadDebt;
+}
+
+UnsentReadGeneration &Thread::unreadReactionsReadDebt() {
+	return _unreadReactionsReadDebt;
+}
+
 HistoryUnreadThings::Proxy Thread::unreadPollVotes() {
 	return {
 		this,

--- a/Telegram/SourceFiles/data/data_thread.h
+++ b/Telegram/SourceFiles/data/data_thread.h
@@ -8,6 +8,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #pragma once
 
 #include "base/flags.h"
+#include "data/data_unsent_read_generation.h"
 #include "dialogs/dialogs_entry.h"
 #include "dialogs/ui/dialogs_message_view.h"
 #include "ui/text/text.h"
@@ -81,6 +82,8 @@ public:
 	[[nodiscard]] HistoryUnreadThings::ConstProxy unreadReactions() const;
 	[[nodiscard]] HistoryUnreadThings::Proxy unreadPollVotes();
 	[[nodiscard]] HistoryUnreadThings::ConstProxy unreadPollVotes() const;
+	[[nodiscard]] UnsentReadGeneration &unreadMentionsReadDebt();
+	[[nodiscard]] UnsentReadGeneration &unreadReactionsReadDebt();
 	virtual void hasUnreadMentionChanged(bool has) = 0;
 	virtual void hasUnreadReactionChanged(bool has) = 0;
 	virtual void hasUnreadPollVoteChanged(bool has) = 0;
@@ -142,6 +145,8 @@ private:
 	Ui::Text::String _cloudDraftTextCache = { st::dialogsTextWidthMin };
 	Dialogs::Ui::MessageView _lastItemDialogsView;
 	std::unique_ptr<HistoryUnreadThings::All> _unreadThings;
+	UnsentReadGeneration _unreadMentionsReadDebt;
+	UnsentReadGeneration _unreadReactionsReadDebt;
 	std::deque<ItemNotification> _notifications;
 
 	base::flags<Flag> _flags;

--- a/Telegram/SourceFiles/data/data_unsent_read_generation.h
+++ b/Telegram/SourceFiles/data/data_unsent_read_generation.h
@@ -1,0 +1,45 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include <cstdint>
+
+namespace Data {
+
+class UnsentReadGeneration final {
+public:
+	using Generation = std::uint32_t;
+
+	[[nodiscard]] explicit operator bool() const {
+		return _pending;
+	}
+
+	[[nodiscard]] Generation generation() const {
+		return _pending ? _generation : 0;
+	}
+
+	void add() {
+		if (++_generation == 0) {
+			++_generation;
+		}
+		_pending = true;
+	}
+
+	void sent(Generation generation) {
+		if (_pending && _generation == generation) {
+			_pending = false;
+		}
+	}
+
+private:
+	Generation _generation = 0;
+	bool _pending = false;
+
+};
+
+} // namespace Data

--- a/Telegram/SourceFiles/data/data_unsent_read_till.h
+++ b/Telegram/SourceFiles/data/data_unsent_read_till.h
@@ -1,0 +1,44 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+namespace Data {
+
+template <typename Id>
+class UnsentReadTill final {
+public:
+	[[nodiscard]] explicit operator bool() const {
+		return (_till != Id());
+	}
+
+	[[nodiscard]] Id till() const {
+		return _till;
+	}
+
+	void add(Id till) {
+		if (_till < till) {
+			_till = till;
+		}
+	}
+
+	[[nodiscard]] Id with(Id till) const {
+		return (_till < till) ? till : _till;
+	}
+
+	void sent(Id till) {
+		if (_till <= till) {
+			_till = Id();
+		}
+	}
+
+private:
+	Id _till = Id();
+
+};
+
+} // namespace Data

--- a/Telegram/SourceFiles/tests/ayu_ghost_mode_peer_exceptions_test.cpp
+++ b/Telegram/SourceFiles/tests/ayu_ghost_mode_peer_exceptions_test.cpp
@@ -1,0 +1,52 @@
+// This is the source code of AyuGram for Desktop.
+//
+// We do not and cannot prevent the use of our code,
+// but be respectful and credit the original author.
+//
+// Copyright @Radolyn, 2026
+#include "ayu/ghost_mode_peer_exceptions.h"
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace {
+
+void Require(bool condition) {
+	if (!condition) {
+		std::abort();
+	}
+}
+
+} // namespace
+
+int main() {
+	using Exceptions = Ayu::GhostModePeerExceptions;
+
+	constexpr auto alice = std::uint64_t(101);
+	constexpr auto bob = std::uint64_t(202);
+	constexpr auto carol = std::uint64_t(303);
+
+	auto exceptions = Exceptions();
+	Require(exceptions.shouldSend(true, std::nullopt));
+	Require(exceptions.shouldSend(true, alice));
+	Require(!exceptions.shouldSend(false, std::nullopt));
+	Require(!exceptions.shouldSend(false, alice));
+
+	Require(exceptions.set(alice, true));
+	Require(!exceptions.set(alice, true));
+	Require(exceptions.contains(alice));
+	Require(exceptions.shouldSend(false, alice));
+	Require(!exceptions.shouldSend(false, bob));
+
+	Require(exceptions.set(alice, false));
+	Require(!exceptions.set(alice, false));
+	Require(!exceptions.contains(alice));
+	Require(!exceptions.shouldSend(false, alice));
+
+	Require(exceptions.set(carol, true));
+	exceptions.replace(Exceptions::Values{ alice, bob });
+	Require(exceptions.values().size() == 2);
+	Require(exceptions.shouldSend(false, alice));
+	Require(exceptions.shouldSend(false, bob));
+	Require(!exceptions.contains(carol));
+}

--- a/Telegram/SourceFiles/tests/data_unsent_read_generation_test.cpp
+++ b/Telegram/SourceFiles/tests/data_unsent_read_generation_test.cpp
@@ -1,0 +1,52 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "data/data_unsent_read_generation.h"
+
+#include <cstdlib>
+
+namespace {
+
+void Require(bool condition) {
+	if (!condition) {
+		std::abort();
+	}
+}
+
+} // namespace
+
+int main() {
+	auto debt = Data::UnsentReadGeneration();
+	Require(!debt);
+	Require(debt.generation() == 0);
+
+	debt.add();
+	const auto first = debt.generation();
+	Require(static_cast<bool>(debt));
+	Require(first != 0);
+
+	debt.add();
+	const auto second = debt.generation();
+	Require(second != first);
+
+	debt.sent(first);
+	Require(static_cast<bool>(debt));
+	Require(debt.generation() == second);
+
+	debt.sent(second);
+	Require(!debt);
+	Require(debt.generation() == 0);
+
+	debt.add();
+	const auto third = debt.generation();
+	Require(third != second);
+	debt.sent(second);
+	Require(static_cast<bool>(debt));
+	Require(debt.generation() == third);
+	debt.sent(third);
+	Require(!debt);
+}

--- a/Telegram/SourceFiles/tests/data_unsent_read_till_test.cpp
+++ b/Telegram/SourceFiles/tests/data_unsent_read_till_test.cpp
@@ -1,0 +1,44 @@
+// This is the source code of AyuGram for Desktop.
+//
+// We do not and cannot prevent the use of our code,
+// but be respectful and credit the original author.
+//
+// Copyright @Radolyn, 2026
+#include "data/data_unsent_read_till.h"
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace {
+
+void Require(bool condition) {
+	if (!condition) {
+		std::abort();
+	}
+}
+
+} // namespace
+
+int main() {
+	using State = Data::UnsentReadTill<std::uint64_t>;
+
+	auto state = State();
+	Require(!state);
+	Require(state.with(10) == 10);
+
+	state.add(10);
+	state.add(5);
+	Require(static_cast<bool>(state));
+	Require(state.till() == 10);
+	Require(state.with(7) == 10);
+	Require(state.with(12) == 12);
+
+	state.sent(9);
+	Require(state.till() == 10);
+	state.sent(10);
+	Require(!state);
+
+	state.add(15);
+	state.sent(20);
+	Require(!state);
+}

--- a/Telegram/SourceFiles/window/window_main_menu.cpp
+++ b/Telegram/SourceFiles/window/window_main_menu.cpp
@@ -770,14 +770,8 @@ void MainMenu::setupMenu() {
 				{&st::ayuLReadMenuIcon}
 			)->setClickedCallback([=]() mutable
 			{
-				auto &ghost = AyuSettings::ghost(&controller->session());
-				const auto prev = ghost.sendReadMessages();
-				ghost.setSendReadMessages(false);
-
 				const auto chats = controller->session().data().chatsList();
-				MarkAsReadChatList(chats);
-
-				ghost.setSendReadMessages(prev);
+				::MarkAsReadChatList(chats, true);
 			});
 		}
 

--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
@@ -1758,6 +1758,7 @@ void Filler::fillContextMenuActions() {
 		}
 	}
 	addClearHistory();
+	AyuUi::AddGhostTrustedChatExceptionAction(_peer, _addAction);
 	AyuUi::AddDeleteOwnMessagesAction(_peer, _topic, _controller, _addAction);
 	addDeleteChat();
 	addLeaveChat();
@@ -1809,6 +1810,7 @@ void Filler::fillProfileActions() {
 	addToggleTopicClosed();
 	AyuUi::AddOpenChannelAction(_peer, _controller, _addAction);
 	AyuUi::AddShadowBanAction(_peer, _addAction);
+	AyuUi::AddGhostTrustedChatExceptionAction(_peer, _addAction);
 	addViewDiscussion();
 	addDirectMessages();
 	addExportChat();

--- a/Telegram/cmake/tests.cmake
+++ b/Telegram/cmake/tests.cmake
@@ -42,3 +42,51 @@ set_target_properties(test_text PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINA
 add_dependencies(Telegram test_text)
 
 target_prepare_qrc(test_text)
+
+add_executable(test_data_unsent_read_generation)
+init_target(test_data_unsent_read_generation "(tests)")
+
+target_include_directories(test_data_unsent_read_generation PRIVATE ${src_loc})
+
+nice_target_sources(test_data_unsent_read_generation ${src_loc}
+PRIVATE
+    tests/data_unsent_read_generation_test.cpp
+)
+
+set_target_properties(test_data_unsent_read_generation PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+add_dependencies(Telegram test_data_unsent_read_generation)
+
+add_executable(test_data_unsent_read_till)
+init_target(test_data_unsent_read_till "(tests)")
+
+target_include_directories(test_data_unsent_read_till PRIVATE ${src_loc})
+
+nice_target_sources(test_data_unsent_read_till ${src_loc}
+PRIVATE
+    tests/data_unsent_read_till_test.cpp
+)
+
+set_target_properties(test_data_unsent_read_till PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+add_dependencies(Telegram test_data_unsent_read_till)
+
+add_executable(test_ayu_ghost_mode_peer_exceptions)
+init_target(test_ayu_ghost_mode_peer_exceptions "(tests)")
+
+target_include_directories(test_ayu_ghost_mode_peer_exceptions PRIVATE ${src_loc})
+
+nice_target_sources(test_ayu_ghost_mode_peer_exceptions ${src_loc}
+PRIVATE
+    tests/ayu_ghost_mode_peer_exceptions_test.cpp
+)
+
+set_target_properties(test_ayu_ghost_mode_peer_exceptions PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+add_dependencies(Telegram test_ayu_ghost_mode_peer_exceptions)


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request was AI-generated with Codex and then reviewed through targeted tests, a production build, and local app testing.

## Summary

- Add persistent Ghost Mode trusted-chat exceptions for non-bot, non-self private users.
- Let trusted private chats bypass Ghost Mode defaults for message/content receipts and chat activity actions sent through `messages.setTyping`, including typing, recording, and uploads.
- Keep groups, channels, stories, and non-trusted chats on the existing global Ghost Mode behavior.
- Migrate the legacy local `readReceiptExceptions` setting to `trustedChatExceptions` when loading settings.

Trusted chats can be toggled from a private chat's context menu with **Always Send Reads and Activity** / **Use Ghost Mode Defaults**.

## Read-state handling

An explicit local-only read still records pending server read state. A later server read catches up read history, manual unread marks, mentions, reactions, and forum-topic state. Pending state is retained after RPC failures and guarded against stale callbacks.

## Privacy behavior

Manual testing observed that reading a trusted chat also made the account appear online. A trusted exception should therefore be treated as presence-revealing while reading; it is not a guarantee of hidden online status for that chat.

## Validation

- `git diff --check`
- `test_ayu_ghost_mode_peer_exceptions`
- `test_data_unsent_read_generation`
- `test_data_unsent_read_till`
- `cmake --build out --target Telegram` on macOS arm64
- Ad-hoc signed app bundle installed and launched locally
- Two-account manual verification confirmed persistence after restart, trusted-chat reads and activity, and restoration of Ghost Mode behavior after removing the exception
