### PR TITLE
Document Apple Silicon terminal build

### DIFF
--- a/docs/building-mac.md
+++ b/docs/building-mac.md
@@ -31,3 +31,15 @@ Go to ***BuildPath*/tdesktop/Telegram** and run
     ./configure.sh -D TDESKTOP_API_ID=2040 -D TDESKTOP_API_HASH=b18441a1ff607e10a989891a5462e627
 
 Then launch Xcode, open ***BuildPath*/tdesktop/out/Telegram.xcodeproj** and build for Debug / Release.
+
+#### Apple Silicon build from Terminal
+
+To build a native Release version on an Apple Silicon Mac without opening Xcode, go to ***BuildPath*/tdesktop** and run
+
+    cmake --build out --config Release --target Telegram -- -arch arm64 -quiet
+
+The application will be created at ***BuildPath*/tdesktop/out/Release/AyuGram.app**. You can verify the executable architecture with
+
+    file out/Release/AyuGram.app/Contents/MacOS/AyuGram
+
+The output should contain `Mach-O 64-bit executable arm64`.


### PR DESCRIPTION
Added the command I used to build a native arm64 Release version from Terminal.

The guide now also shows where AyuGram.app is created and how to check that the executable is arm64.

Tested on an Apple Silicon Mac with Xcode 26.6. The Release build completes and file reports a Mach-O arm64 executable.