### PR TITLE
Add saving and rendering all media types in deleted messages history

### DIFF
--- a/Telegram/SourceFiles/ayu/data/messages_storage.cpp
+++ b/Telegram/SourceFiles/ayu/data/messages_storage.cpp
@@ -1,4 +1,4 @@
-﻿// This is the source code of AyuGram for Desktop.
+// This is the source code of AyuGram for Desktop.
 //
 // We do not and cannot prevent the use of our code,
 // but be respectful and credit the original author.
@@ -74,21 +74,14 @@ void map(not_null<HistoryItem*> item, AyuMessageBase &message) {
 	message.text = serializedText.first;
 	message.textEntities = serializedText.second;
 
-	// todo: implement mapping
-	message.mediaPath = "/";
-	// message.hqThumbPath
-	message.documentType = 0; // document type none
-	// message.documentSerialized
-	// message.thumbsSerialized
-	// message.documentAttributesSerialized
-	// message.mimeType
+	AyuMapper::mapMediaToMessage(item, message);
 }
 
 void addEditedMessage(not_null<HistoryItem *> item) {
 	EditedMessage message;
 	map(item, message);
 
-	if (message.text.empty()) {
+	if (message.text.empty() && message.documentType == AyuMapper::kDocumentTypeNone) {
 		return;
 	}
 
@@ -115,7 +108,7 @@ void addDeletedMessage(not_null<HistoryItem*> item) {
 	DeletedMessage message;
 	map(item, message);
 
-	if (message.text.empty()) {
+	if (message.text.empty() && message.documentType == AyuMapper::kDocumentTypeNone) {
 		return;
 	}
 

--- a/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
+++ b/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
@@ -136,12 +136,13 @@ void GenerateItems(
 
 	auto media = MTP_messageMediaEmpty();
 	if (!message.documentSerialized.empty()) {
-		const auto from = reinterpret_cast<const mtpPrime*>(message.documentSerialized.data());
-		const auto end = from + message.documentSerialized.size() / sizeof(mtpPrime);
-		auto current = from;
-		MTPMessageMedia parsed;
-		if (parsed.read(current, end) && parsed.type() != 0) {
-			media = std::move(parsed);
+		auto parsed = AyuMapper::deserializeObject<MTPMessageMedia>(message.documentSerialized);
+		if (parsed.type() != 0) {
+			if (parsed.type() == mtpc_messageMediaPhoto && !parsed.c_messageMediaPhoto().vphoto()) {
+				// Ignore legacy broken photo payload
+			} else {
+				media = std::move(parsed);
+			}
 		}
 	}
 

--- a/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
+++ b/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp
@@ -14,15 +14,20 @@
 #include "base/unixtime.h"
 #include "core/application.h"
 #include "core/click_handler_types.h"
+#include "core/file_location.h"
 #include "data/data_channel.h"
+#include "data/data_document.h"
 #include "data/data_file_origin.h"
 #include "data/data_forum_topic.h"
+#include "data/data_media_types.h"
+#include "data/data_photo.h"
 #include "data/data_session.h"
 #include "data/data_user.h"
 #include "history/history.h"
 #include "history/view/history_view_element.h"
 #include "ui/basic_click_handlers.h"
 #include "ui/text/text_utilities.h"
+#include <QtCore/QFileInfo>
 
 namespace MessageHistory {
 
@@ -82,7 +87,7 @@ void GenerateItems(
 		return callback(OwnedItem(delegate, item), sentDate, realId);
 	};
 
-	const auto makeSimpleTextMessage = [&](TextWithEntities &&text)
+	const auto makeMessageWithMedia = [&](TextWithEntities &&text, MTPMessageMedia &&media)
 	{
 		base::flags<MessageFlag> flags = MessageFlag::AdminLogEntry;
 		if (from) {
@@ -94,31 +99,53 @@ void GenerateItems(
 			flags |= MessageFlag::HasPostAuthor;
 		}
 
-		return history->makeMessage({
-										.id = history->nextNonHistoryEntryId(),
-										.flags = flags,
-										.from = from ? from->id : 0,
-										.date = date,
-										.postAuthor = !message.postAuthor.empty()
-														  ? QString::fromStdString(message.postAuthor)
-														  : from
-																? QString()
-																: QString("unknown user: %1").arg(message.fromId),
-									},
-									std::move(text),
-									MTP_messageMediaEmpty());
-	};
+		auto item = history->makeMessage({
+			.id = history->nextNonHistoryEntryId(),
+			.flags = flags,
+			.from = from ? from->id : 0,
+			.date = date,
+			.postAuthor = !message.postAuthor.empty()
+				? QString::fromStdString(message.postAuthor)
+				: from
+					? QString()
+					: QString("unknown user: %1").arg(message.fromId),
+		}, std::move(text), std::move(media));
 
-	const auto addSimpleTextMessage = [&](TextWithEntities &&text)
-	{
-		addPart(makeSimpleTextMessage(std::move(text)));
+		if (!message.mediaPath.empty()) {
+			const auto localPath = QString::fromStdString(message.mediaPath);
+			if (QFileInfo::exists(localPath)) {
+				if (const auto m = item->media()) {
+					if (const auto photo = m->photo()) {
+						photo->setLocation(Core::FileLocation(localPath));
+					} else if (const auto doc = m->document()) {
+						doc->setLocation(Core::FileLocation(localPath));
+					}
+				}
+			}
+		}
+
+		return item;
 	};
 
 	const auto text = QString::fromStdString(message.text);
 	auto textAndEntities = Ui::Text::WithEntities(text);
-	const auto entities = AyuMapper::deserializeTextWithEntities(message.textEntities);
-	textAndEntities.entities = Api::EntitiesFromMTP(&history->session(), entities.v);
-	addSimpleTextMessage(std::move(textAndEntities));
+	if (!message.textEntities.empty()) {
+		const auto entities = AyuMapper::deserializeTextWithEntities(message.textEntities);
+		textAndEntities.entities = Api::EntitiesFromMTP(&history->session(), entities.v);
+	}
+
+	auto media = MTP_messageMediaEmpty();
+	if (!message.documentSerialized.empty()) {
+		const auto from = reinterpret_cast<const mtpPrime*>(message.documentSerialized.data());
+		const auto end = from + message.documentSerialized.size() / sizeof(mtpPrime);
+		auto current = from;
+		MTPMessageMedia parsed;
+		if (parsed.read(current, end) && parsed.type() != 0) {
+			media = std::move(parsed);
+		}
+	}
+
+	addPart(makeMessageWithMedia(std::move(textAndEntities), std::move(media)));
 }
 
 } // namespace MessageHistory

--- a/Telegram/SourceFiles/ayu/utils/ayu_mapper.cpp
+++ b/Telegram/SourceFiles/ayu/utils/ayu_mapper.cpp
@@ -8,6 +8,14 @@
 
 #include "apiwrap.h"
 #include "api/api_text_entities.h"
+#include "core/file_location.h"
+#include "data/data_document.h"
+#include "data/data_document_media.h"
+#include "data/data_file_origin.h"
+#include "data/data_media_types.h"
+#include "data/data_photo.h"
+#include "data/data_photo_media.h"
+#include "data/stickers/data_stickers.h"
 #include "history/history.h"
 #include "history/history_item.h"
 #include "history/history_item_components.h"
@@ -43,31 +51,7 @@ constexpr auto kMessageFlagHasTTL = 0x02000000;
 constexpr auto kMessageFlagInvertMedia = 0x08000000;
 constexpr auto kMessageFlagHasSavedPeer = 0x10000000;
 
-template<typename MTPObject>
-std::vector<char> serializeObject(MTPObject object) {
-	mtpBuffer buffer;
-	object.write(buffer);
 
-	const auto from = reinterpret_cast<char*>(buffer.data());
-	const auto end = from + buffer.size() * sizeof(mtpPrime);
-
-	std::vector<char> entities(from, end);
-	return entities;
-}
-
-template<typename MTPObject>
-MTPObject deserializeObject(std::vector<char> serialized) {
-	gsl::span<char> span(serialized.data(), serialized.size());
-
-	auto from = reinterpret_cast<const mtpPrime*>(span.data());
-	const auto end = from + span.size() / sizeof(mtpPrime);
-
-	MTPObject data;
-	if (!data.read(from, end)) {
-		LOG(("AyuMapper: Failed to deserialize object"));
-	}
-	return data;
-}
 
 std::pair<std::string, std::vector<char>> serializeTextWithEntities(not_null<HistoryItem*> item) {
 	if (item->emptyText()) {
@@ -89,7 +73,7 @@ std::pair<std::string, std::vector<char>> serializeTextWithEntities(not_null<His
 	return std::make_pair(textWithEntities.text.toStdString(), entities);
 }
 
-MTPVector<MTPMessageEntity> deserializeTextWithEntities(std::vector<char> serialized) {
+MTPVector<MTPMessageEntity> deserializeTextWithEntities(const std::vector<char> &serialized) {
 	return deserializeObject<MTPVector<MTPMessageEntity>>(serialized);
 }
 
@@ -206,6 +190,258 @@ int mapItemFlagsToMTPFlags(not_null<HistoryItem*> item) {
 	}
 
 	return flags;
+}
+
+void mapMediaToMessage(not_null<HistoryItem*> item, AyuMessageBase &message) {
+	const auto media = item->media();
+	if (!media) {
+		message.documentType = kDocumentTypeNone;
+		return;
+	}
+
+	if (const auto photo = media->photo()) {
+		message.documentType = kDocumentTypePhoto;
+
+		uint64 accessHash = 0;
+		QByteArray fileRef = photo->fileReference();
+		photo->mtpInput().match([&](const MTPDinputPhoto &p) {
+			accessHash = p.vaccess_hash().v;
+			if (fileRef.isEmpty()) {
+				fileRef = p.vfile_reference().v;
+			}
+		}, [](const MTPDinputPhotoEmpty &) {});
+
+		auto photoSizes = QVector<MTPPhotoSize>();
+		const auto w = std::max(photo->width(), 1);
+		const auto h = std::max(photo->height(), 1);
+
+		const auto stripped = photo->inlineThumbnailBytes();
+		if (!stripped.isEmpty()) {
+			photoSizes.push_back(MTP_photoStrippedSize(
+				MTP_string("i"),
+				MTP_bytes(stripped)));
+		}
+
+		if (photo->hasExact(Data::PhotoSize::Thumbnail)) {
+			if (const auto sz = photo->size(Data::PhotoSize::Thumbnail)) {
+				photoSizes.push_back(MTP_photoSize(
+					MTP_string("m"),
+					MTP_int(sz->width()),
+					MTP_int(sz->height()),
+					MTP_int(photo->imageByteSize(Data::PhotoSize::Thumbnail))));
+			}
+		}
+
+		const auto largeByteSize = photo->imageByteSize(Data::PhotoSize::Large);
+		photoSizes.push_back(MTP_photoSize(
+			MTP_string("y"),
+			MTP_int(w),
+			MTP_int(h),
+			MTP_int(largeByteSize > 0 ? largeByteSize : 0)));
+
+		const auto mtpPhoto = MTP_photo(
+			MTP_flags(0),
+			MTP_long(photo->id),
+			MTP_long(accessHash),
+			MTP_bytes(fileRef),
+			MTP_int(photo->date()),
+			MTP_vector<MTPPhotoSize>(photoSizes),
+			MTPVector<MTPVideoSize>(),
+			MTP_int(photo->getDC()));
+
+		using PhotoFlag = MTPDmessageMediaPhoto::Flag;
+		auto flags = MTPDmessageMediaPhoto::Flags(PhotoFlag::f_photo);
+		if (media->hasSpoiler()) {
+			flags |= PhotoFlag::f_spoiler;
+		}
+		const auto mtpMedia = MTP_messageMediaPhoto(
+			MTP_flags(flags),
+			mtpPhoto,
+			MTPint(),
+			MTPDocument());
+
+		message.documentSerialized = serializeObject(MTPMessageMedia(mtpMedia));
+
+		const auto loc = photo->location(true);
+		if (!loc.isEmpty()) {
+			message.mediaPath = loc.name().toStdString();
+		}
+	} else if (const auto doc = media->document()) {
+		if (doc->isVoiceMessage()) {
+			message.documentType = kDocumentTypeVoice;
+		} else if (doc->isVideoMessage()) {
+			message.documentType = kDocumentTypeVideoNote;
+		} else if (doc->isAnimation() || doc->isGifv()) {
+			message.documentType = kDocumentTypeAnimation;
+		} else if (doc->sticker()) {
+			message.documentType = kDocumentTypeSticker;
+		} else if (doc->isVideoFile()) {
+			message.documentType = kDocumentTypeVideo;
+		} else if (doc->isAudioFile()) {
+			message.documentType = kDocumentTypeAudio;
+		} else {
+			message.documentType = kDocumentTypeFile;
+		}
+		message.mimeType = doc->mimeString().toStdString();
+
+		uint64 accessHash = 0;
+		QByteArray fileRef = doc->fileReference();
+		doc->mtpInput().match([&](const MTPDinputDocument &d) {
+			accessHash = d.vaccess_hash().v;
+			if (fileRef.isEmpty()) {
+				fileRef = d.vfile_reference().v;
+			}
+		}, [](const MTPDinputDocumentEmpty &) {});
+
+		auto attributes = QVector<MTPDocumentAttribute>();
+
+		const auto filename = doc->filename();
+		if (!filename.isEmpty()) {
+			attributes.push_back(MTP_documentAttributeFilename(MTP_string(filename)));
+		}
+
+		const auto dims = doc->dimensions;
+		const auto durationSec = int(doc->duration() / 1000);
+		const auto durationDouble = doc->duration() / 1000.;
+
+		if (doc->isVoiceMessage()) {
+			auto flags = MTPDdocumentAttributeAudio::Flags(MTPDdocumentAttributeAudio::Flag::f_voice);
+			QByteArray waveBytes;
+			if (const auto voice = doc->voice()) {
+				if (!voice->waveform.isEmpty()) {
+					flags |= MTPDdocumentAttributeAudio::Flag::f_waveform;
+					waveBytes = documentWaveformEncode5bit(voice->waveform);
+				}
+			}
+			attributes.push_back(MTP_documentAttributeAudio(
+				MTP_flags(flags),
+				MTP_int(durationSec),
+				MTPstring(),
+				MTPstring(),
+				MTP_bytes(waveBytes)));
+		} else if (doc->isVideoMessage() || doc->isVideoFile()) {
+			auto flags = MTPDdocumentAttributeVideo::Flags(0);
+			using VideoFlag = MTPDdocumentAttributeVideo::Flag;
+			if (doc->isVideoMessage()) {
+				flags |= VideoFlag::f_round_message;
+			}
+			if (doc->supportsStreaming()) {
+				flags |= VideoFlag::f_supports_streaming;
+			}
+			attributes.push_back(MTP_documentAttributeVideo(
+				MTP_flags(flags),
+				MTP_double(durationDouble),
+				MTP_int(dims.width()),
+				MTP_int(dims.height()),
+				MTPint(),
+				MTPdouble(),
+				MTPstring()));
+		} else if (const auto song = doc->song()) {
+			const auto flags = MTPDdocumentAttributeAudio::Flag::f_title
+				| MTPDdocumentAttributeAudio::Flag::f_performer;
+			attributes.push_back(MTP_documentAttributeAudio(
+				MTP_flags(flags),
+				MTP_int(durationSec),
+				MTP_string(song->title),
+				MTP_string(song->performer),
+				MTPbytes()));
+		} else if (const auto sticker = doc->sticker()) {
+			MTPInputStickerSet inputSet = MTP_inputStickerSetEmpty();
+			if (sticker->set.id != 0) {
+				inputSet = MTP_inputStickerSetID(
+					MTP_long(sticker->set.id),
+					MTP_long(sticker->set.accessHash));
+			} else if (!sticker->set.shortName.isEmpty()) {
+				inputSet = MTP_inputStickerSetShortName(
+					MTP_string(sticker->set.shortName));
+			}
+			attributes.push_back(MTP_documentAttributeSticker(
+				MTP_flags(0),
+				MTP_string(sticker->alt),
+				inputSet,
+				MTPMaskCoords()));
+			if (dims.width() > 0 && dims.height() > 0) {
+				attributes.push_back(MTP_documentAttributeImageSize(
+					MTP_int(dims.width()),
+					MTP_int(dims.height())));
+			}
+		} else if (doc->isAnimation() || doc->isGifv()) {
+			attributes.push_back(MTP_documentAttributeAnimated());
+			if (dims.width() > 0 && dims.height() > 0) {
+				attributes.push_back(MTP_documentAttributeImageSize(
+					MTP_int(dims.width()),
+					MTP_int(dims.height())));
+			}
+		} else if (dims.width() > 0 && dims.height() > 0) {
+			attributes.push_back(MTP_documentAttributeImageSize(
+				MTP_int(dims.width()),
+				MTP_int(dims.height())));
+		}
+
+		auto thumbs = QVector<MTPPhotoSize>();
+		const auto inlineThumb = doc->inlineThumbnailBytes();
+		if (!inlineThumb.isEmpty()) {
+			thumbs.push_back(MTP_photoStrippedSize(
+				MTP_string("i"),
+				MTP_bytes(inlineThumb)));
+		} else if (doc->hasThumbnail()) {
+			const auto loc = doc->thumbnailLocation();
+			const auto byteSize = doc->thumbnailByteSize();
+			thumbs.push_back(MTP_photoSize(
+				MTP_string("m"),
+				MTP_int(loc.width() > 0 ? loc.width() : 100),
+				MTP_int(loc.height() > 0 ? loc.height() : 100),
+				MTP_int(byteSize > 0 ? byteSize : 0)));
+		}
+
+		const auto mtpDoc = MTP_document(
+			MTP_flags(0),
+			MTP_long(doc->id),
+			MTP_long(accessHash),
+			MTP_bytes(fileRef),
+			MTP_int(doc->date),
+			MTP_string(doc->mimeString()),
+			MTP_long(doc->size),
+			MTP_vector<MTPPhotoSize>(thumbs),
+			MTPVector<MTPVideoSize>(),
+			MTP_int(doc->getDC()),
+			MTP_vector<MTPDocumentAttribute>(attributes));
+
+		using DocFlag = MTPDmessageMediaDocument::Flag;
+		auto flags = MTPDmessageMediaDocument::Flags(DocFlag::f_document);
+		if (doc->isVoiceMessage()) {
+			flags |= DocFlag::f_voice;
+		} else if (doc->isVideoMessage()) {
+			flags |= DocFlag::f_round | DocFlag::f_video;
+		} else if (doc->isVideoFile()) {
+			flags |= DocFlag::f_video;
+		}
+		if (media->hasSpoiler()) {
+			flags |= DocFlag::f_spoiler;
+		}
+		if (media->ttlSeconds() > 0) {
+			flags |= DocFlag::f_ttl_seconds;
+		}
+		const auto mtpMedia = MTP_messageMediaDocument(
+			MTP_flags(flags),
+			mtpDoc,
+			MTPVector<MTPDocument>(),
+			MTPPhoto(),
+			MTP_int(media->ttlSeconds() > 0 ? int(media->ttlSeconds() / 1000) : 0),
+			MTPint());
+
+		message.documentSerialized = serializeObject(MTPMessageMedia(mtpMedia));
+
+		const auto loc = doc->location(true);
+		if (!loc.isEmpty()) {
+			message.mediaPath = loc.name().toStdString();
+		} else {
+			const auto fp = doc->filepath(true);
+			if (!fp.isEmpty()) {
+				message.mediaPath = fp.toStdString();
+			}
+		}
+	}
 }
 
 }

--- a/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
+++ b/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
@@ -41,12 +41,17 @@ template<typename MTPObject>
 	if (serialized.empty()) {
 		return MTPObject();
 	}
+	if (serialized.size() % sizeof(mtpPrime) != 0) {
+		return MTPObject();
+	}
 	const auto from = reinterpret_cast<const mtpPrime*>(serialized.data());
 	const auto end = from + serialized.size() / sizeof(mtpPrime);
 
 	auto current = from;
 	MTPObject result;
-	(void)result.read(current, end);
+	if (!result.read(current, end)) {
+		return MTPObject();
+	}
 
 	return result;
 }

--- a/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
+++ b/Telegram/SourceFiles/ayu/utils/ayu_mapper.h
@@ -6,16 +6,55 @@
 // Copyright @Radolyn, 2026
 #pragma once
 
+#include "ayu/data/entities.h"
+#include "mtproto/connection_abstract.h"
+#include "mtproto/details/mtproto_dump_to_text.h"
+#include "scheme.h"
+
+class HistoryItem;
+
 namespace AyuMapper {
 
-template<typename MTPObject>
-[[nodiscard]] MTPObject deserializeObject(std::vector<char> serialized);
+constexpr int kDocumentTypeNone = 0;
+constexpr int kDocumentTypePhoto = 1;
+constexpr int kDocumentTypeVoice = 2;
+constexpr int kDocumentTypeVideoNote = 3;
+constexpr int kDocumentTypeAnimation = 4;
+constexpr int kDocumentTypeVideo = 5;
+constexpr int kDocumentTypeSticker = 6;
+constexpr int kDocumentTypeAudio = 7;
+constexpr int kDocumentTypeFile = 8;
 
 template<typename MTPObject>
-[[nodiscard]] std::vector<char> serializeObject(MTPObject object);
+[[nodiscard]] std::vector<char> serializeObject(MTPObject object) {
+	mtpBuffer buffer;
+	object.write(buffer);
+
+	const auto from = reinterpret_cast<const char*>(buffer.data());
+	const auto end = from + buffer.size() * sizeof(mtpPrime);
+
+	return std::vector<char>(from, end);
+}
+
+template<typename MTPObject>
+[[nodiscard]] MTPObject deserializeObject(const std::vector<char> &serialized) {
+	if (serialized.empty()) {
+		return MTPObject();
+	}
+	const auto from = reinterpret_cast<const mtpPrime*>(serialized.data());
+	const auto end = from + serialized.size() / sizeof(mtpPrime);
+
+	auto current = from;
+	MTPObject result;
+	(void)result.read(current, end);
+
+	return result;
+}
 
 std::pair<std::string, std::vector<char>> serializeTextWithEntities(not_null<HistoryItem*> item);
-[[nodiscard]] MTPVector<MTPMessageEntity> deserializeTextWithEntities(std::vector<char> serialized);
+[[nodiscard]] MTPVector<MTPMessageEntity> deserializeTextWithEntities(const std::vector<char> &serialized);
 int mapItemFlagsToMTPFlags(not_null<HistoryItem*> item);
+
+void mapMediaToMessage(not_null<HistoryItem*> item, AyuMessageBase &message);
 
 } // namespace AyuMapper


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated / assisted with AI in accordance with repository guidelines.

## Summary

This PR provides a complete, robust implementation of media support for AyuGram's deleted/edited messages history, **superseding #419**. 

This PR adds full media support for AyuGram's deleted/edited messages history. Previously, only text was saved and replayed; now photos, videos, voice messages, video notes, stickers, animations, audio files, and generic documents are properly serialized, persisted, and restored in the UI.

## Changes

### Core Serialization ([`ayu_mapper.cpp`](file:///c:/Users/Tymur/Desktop/Ayugram/AyuGramDesktop/Telegram/SourceFiles/ayu/utils/ayu_mapper.cpp) / [`ayu_mapper.h`](file:///c:/Users/Tymur/Desktop/Ayugram/AyuGramDesktop/Telegram/SourceFiles/ayu/utils/ayu_mapper.h))
- Added `mapMediaToMessage()` to inspect the live `HistoryItem` and serialize its media into `documentSerialized` using native MTProto binary serialization.
- Moved template helpers `serializeObject` / `deserializeObject` to the header for reuse across translation units.
- Hardened `deserializeObject` with `% sizeof(mtpPrime)` buffer alignment checks and `.read()` error handling to return an empty object instead of triggering undefined behavior on corrupted database payloads.

### Storage ([`messages_storage.cpp`](file:///c:/Users/Tymur/Desktop/Ayugram/AyuGramDesktop/Telegram/SourceFiles/ayu/data/messages_storage.cpp))
- Replaced stub TODOs with actual `AyuMapper::mapMediaToMessage()` calls.
- Updated the guard condition: messages without text **and** without media (`kDocumentTypeNone`) are skipped, properly preserving media-only messages (such as standalone stickers and photos).

### Rendering & History UI ([`history_item.cpp`](file:///c:/Users/Tymur/Desktop/Ayugram/AyuGramDesktop/Telegram/SourceFiles/ayu/ui/message_history/history_item.cpp))
- Media is deserialized via `AyuMapper::deserializeObject<MTPMessageMedia>()` (removing duplicate buffer arithmetic).
- Handled legacy/broken photo payloads (`messageMediaPhoto` without inner photo data) gracefully to maintain backward compatibility with older database rows.
- If a cached file exists at `mediaPath`, it is linked to the reconstructed `HistoryItem` via `photo->setLocation()` / `doc->setLocation()`, ensuring thumbnails and media previews render properly.

## Testing

Manually verified on Debug build:
- **Plain text messages**: saved and restored correctly.
- **Photos** (with & without spoiler): saved and previewed.
- **Voice messages**: waveform and duration preserved.
- **Video notes** (round video): round flag and playback preserved.
- **Stickers**: emoji alt and sticker set reference preserved.
- **GIFs / Animations**: animated flag and playback preserved.
- **Audio / Music**: performer and track title metadata preserved.
- **Generic files**: filename and MIME type preserved.
- **Message filters**: deleted media-only and text-only messages saved; messages with neither text nor media are correctly skipped.

## Notes & Limitations

- If a media file was **not downloaded** prior to message deletion on Telegram servers, `mediaPath` will be empty and the original media cannot be fetched from the network (as Telegram invalidates file references upon deletion).
- The `documentType` field is stored for future enhancements (e.g. per-type media filtering in the UI).