### PR TITLE
Build optimized macOS previews with portable CI and bundle icons

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,36 @@
+name: Source checks
+
+on:
+  pull_request:
+  push:
+    paths-ignore: ['**.md', 'LICENSE', 'LEGAL']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: source-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+      - name: Build configuration tests
+        run: python3 -B -m unittest discover -s Telegram/build -p 'test_*macos*.py'
+      - name: Preparation syntax
+        run: python3 -c 'import ast, pathlib; ast.parse(pathlib.Path("Telegram/build/prepare/prepare.py").read_text())'
+      - name: Workflow validation
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck=

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,173 @@
+name: AyuGram macOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: Target architecture (universal includes Intel and Apple Silicon)
+        type: choice
+        options: [universal, arm64, x86_64]
+        default: universal
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ayugram-macos-${{ github.ref }}-${{ inputs.architecture }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Release ${{ inputs.architecture }}
+    runs-on: macos-15
+    timeout-minutes: 350
+    env:
+      REPO_NAME: AyuGramDesktop
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_MAXSIZE: 2G
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: pch_defines,time_macros
+      TARGET_ARCH: ${{ inputs.architecture }}
+      TDESKTOP_API_ID: ${{ vars.TDESKTOP_API_ID }}
+      TDESKTOP_API_HASH: ${{ secrets.TDESKTOP_API_HASH }}
+
+    steps:
+      - name: Validate build configuration
+        id: target
+        run: |
+          if [[ ! "$TDESKTOP_API_ID" =~ ^[1-9][0-9]*$ || ! "$TDESKTOP_API_HASH" =~ ^[[:xdigit:]]{32}$ ]]; then
+            echo 'Set repository variable TDESKTOP_API_ID and secret TDESKTOP_API_HASH before building.' >&2
+            exit 1
+          fi
+          case "$TARGET_ARCH" in
+            universal) echo 'architectures=x86_64;arm64' >> "$GITHUB_OUTPUT" ;;
+            arm64|x86_64) echo "architectures=$TARGET_ARCH" >> "$GITHUB_OUTPUT" ;;
+            *) exit 1 ;;
+          esac
+
+      - name: Clone sources
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          path: ${{ env.REPO_NAME }}
+          persist-credentials: false
+
+      - name: Install build tools
+        id: toolchain
+        run: |
+          brew install automake libtool meson nasm ninja pkg-config ccache
+          sudo xcode-select -s "$DEVELOPER_DIR"
+          toolchain_id=$( { xcodebuild -version; xcrun --sdk macosx --show-sdk-version; cmake --version; } | shasum -a 256 | cut -c1-16)
+          echo "id=$toolchain_id" >> "$GITHUB_OUTPUT"
+
+      - name: Restore libraries cache
+        id: libraries-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            Libraries
+            ThirdParty
+          key: macos-${{ inputs.architecture }}-release-${{ steps.toolchain.outputs.id }}-${{ hashFiles('AyuGramDesktop/Telegram/build/prepare/**', 'AyuGramDesktop/Telegram/build/qt_version.py') }}
+          restore-keys: |
+            macos-${{ inputs.architecture }}-release-${{ steps.toolchain.outputs.id }}-
+
+      - name: Prepare libraries
+        run: |
+          options=(silent qt-release-only)
+          if [[ "$TARGET_ARCH" != universal ]]; then options+=("mac-$TARGET_ARCH"); fi
+          ./"$REPO_NAME"/Telegram/build/prepare/mac.sh "${options[@]}"
+
+      - name: Free disk space
+        run: find Libraries '(' '(' ! '(' -name '*.a' -o -name '*.h' -o -name '*.hpp' -o -name '*.inc' -o -name '*.cmake' -o -name '*.pc' -o -path '*/include/*' -o -path '*/objects-*' -o -path '*/cache_keys/*' -o -path '*/patches/*' -o -perm +111 ')' -type f ')' -o -empty ')' -delete
+
+      - name: Save libraries cache
+        if: steps.libraries-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            Libraries
+            ThirdParty
+          key: ${{ steps.libraries-cache.outputs.cache-primary-key }}
+
+      - name: Restore compiler cache
+        id: compiler-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ inputs.architecture }}-release-${{ steps.toolchain.outputs.id }}-${{ github.sha }}
+          restore-keys: ccache-${{ inputs.architecture }}-release-${{ steps.toolchain.outputs.id }}-
+
+      - name: Configure AyuGram
+        working-directory: ${{ env.REPO_NAME }}/Telegram
+        env:
+          ARCHITECTURES: ${{ steps.target.outputs.architectures }}
+        run: |
+          mac_arch=$TARGET_ARCH
+          if [[ "$mac_arch" == universal ]]; then mac_arch=''; fi
+          ./configure.sh -G Ninja \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -D "CMAKE_OSX_ARCHITECTURES=$ARCHITECTURES" \
+            -D "DESKTOP_APP_MAC_ARCH=$mac_arch" \
+            -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_OBJC_COMPILER_LAUNCHER=ccache \
+            -D CMAKE_OBJCXX_COMPILER_LAUNCHER=ccache \
+            -D 'CMAKE_CXX_FLAGS=-Xclang -fno-pch-timestamp' \
+            -D 'CMAKE_OBJCXX_FLAGS=-Xclang -fno-pch-timestamp' \
+            -D "TDESKTOP_API_ID=$TDESKTOP_API_ID" \
+            -D "TDESKTOP_API_HASH=$TDESKTOP_API_HASH" \
+            -D DESKTOP_APP_DISABLE_AUTOUPDATE=ON
+          IFS=';' read -r -a architectures <<< "$ARCHITECTURES"
+          python3 build/check_macos_release.py ../out --architectures "${architectures[@]}" --disable-autoupdate
+
+      - name: Build AyuGram
+        working-directory: ${{ env.REPO_NAME }}
+        run: |
+          cmake --build out --parallel 3 --target Telegram
+          ccache --show-stats
+
+      - name: Save compiler cache
+        if: always() && steps.compiler-cache.outputs.cache-primary-key != '' && steps.compiler-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.compiler-cache.outputs.cache-primary-key }}
+
+      - name: Verify and package app
+        working-directory: ${{ env.REPO_NAME }}/out
+        env:
+          ARCHITECTURES: ${{ steps.target.outputs.architectures }}
+        run: |
+          app=AyuGram.app
+          test -s "$app/Contents/Resources/AppIcon-Default.icns"
+          test -s "$app/Contents/Resources/Telegram.rcc"
+          expected=$(tr ';' '\n' <<< "$ARCHITECTURES" | sort)
+          actual=$(lipo -archs "$app/Contents/MacOS/AyuGram" | tr ' ' '\n' | sort)
+          test "$actual" = "$expected"
+          test "$(plutil -extract CFBundleIdentifier raw -o - "$app/Contents/Info.plist")" = one.ayugram.AyuGramDesktop
+          icon_name=$(plutil -extract CFBundleIconFile raw -o - "$app/Contents/Info.plist")
+          test -s "$app/Contents/Resources/$icon_name"
+          /usr/bin/strip -S "$app/Contents/MacOS/AyuGram"
+          codesign --force --deep --sign - "$app"
+          codesign --verify --deep --strict "$app"
+          version=$(awk '$1 == "AppVersionStr" {print $2}' ../Telegram/build/version)
+          test -n "$version"
+          mkdir -p artifacts
+          package="AyuGram-$version-macOS-$TARGET_ARCH"
+          file "$app/Contents/MacOS/AyuGram" > "artifacts/$package-architecture.txt"
+          git rev-parse HEAD > "artifacts/$package-source.txt"
+          ditto -c -k --sequesterRsrc --keepParent "$app" "artifacts/$package.zip"
+          cd artifacts
+          shasum -a 256 "$package.zip" > "$package.zip.sha256"
+
+      - name: Upload AyuGram
+        uses: actions/upload-artifact@v7
+        with:
+          name: AyuGram-macOS-${{ inputs.architecture }}-${{ github.sha }}
+          path: ${{ env.REPO_NAME }}/out/artifacts/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -2328,7 +2328,7 @@ elseif (APPLE)
     target_link_frameworks_weak(Telegram PRIVATE UserNotifications)
 
     set(icons_path ${CMAKE_CURRENT_SOURCE_DIR}/Telegram/Images.xcassets)
-    if (CMAKE_GENERATOR STREQUAL Xcode)
+    if (CMAKE_GENERATOR STREQUAL Xcode AND XCODE_VERSION VERSION_GREATER_EQUAL 26)
         set(ayugram_icons
             Default
             Alt

--- a/Telegram/SourceFiles/platform/mac/specific_mac.mm
+++ b/Telegram/SourceFiles/platform/mac/specific_mac.mm
@@ -68,7 +68,7 @@ namespace {
 
 [[nodiscard]] QImage ResolveBundleIconDefault() {
 	NSString *path = [[NSBundle mainBundle] bundlePath];
-	NSString *icon = [path stringByAppendingString:@"/Contents/Resources/Icon.icns"];
+	NSString *icon = [path stringByAppendingString:@"/Contents/Resources/AppIcon-Default.icns"];
 	NSImage *image = [[NSImage alloc] initWithContentsOfFile:icon];
 	if (!image) {
 		return Window::Logo();

--- a/Telegram/Telegram.plist
+++ b/Telegram/Telegram.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string>AppIcon-Default.icns</string>
 	<key>CFBundleIconName</key>
-	<string>AppIcon-Default.icns</string>
+	<string>AppIcon-Default</string>
     <key>CFBundleIcons</key>
     <dict>
         <key>CFBundlePrimaryIcon</key>

--- a/Telegram/build/check_macos_release.py
+++ b/Telegram/build/check_macos_release.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import re
+import shlex
+from pathlib import Path
+
+
+def check(build, architectures=("arm64",), disable_autoupdate=False):
+    expected = set(architectures)
+    if not expected or not expected <= {"arm64", "x86_64"}:
+        raise ValueError("Unsupported macOS architecture")
+    cache = dict(re.findall(r"^([^:#/][^:=]*):[^=]+=(.*)$", (build / "CMakeCache.txt").read_text(), re.M))
+    if cache.get("CMAKE_BUILD_TYPE") != "Release":
+        raise ValueError("Expected a Release build")
+    if set(cache.get("CMAKE_OSX_ARCHITECTURES", "").split(";")) != expected:
+        raise ValueError("CMake architectures do not match the requested target")
+    if disable_autoupdate and cache.get("DESKTOP_APP_DISABLE_AUTOUPDATE") != "ON":
+        raise ValueError("CI preview artifacts must not install upstream updates")
+    commands = json.loads((build / "compile_commands.json").read_text())
+    product = [
+        entry for entry in commands
+        if "/Telegram/SourceFiles/" in entry["file"]
+    ]
+    if not product:
+        raise ValueError("No application compilation commands")
+    for entry in product:
+        args = entry.get("arguments") or shlex.split(entry["command"])
+        optimization = [arg for arg in args if re.fullmatch(r"-O[0-3szg]", arg)]
+        if not optimization or optimization[-1] not in ("-O2", "-O3", "-Os", "-Oz"):
+            raise ValueError(f"Optimization disabled: {entry['file']}")
+        definitions = {arg[2:].split("=")[0] for arg in args if arg.startswith("-D")}
+        undefinitions = {arg[2:] for arg in args if arg.startswith("-U")}
+        if "_DEBUG" in definitions or "NDEBUG" not in definitions or "NDEBUG" in undefinitions:
+            raise ValueError(f"Debug configuration: {entry['file']}")
+        actual = {args[i + 1] for i, arg in enumerate(args[:-1]) if arg == "-arch"}
+        if actual != expected or args[-1:] == ["-arch"]:
+            raise ValueError(f"Wrong architecture: {entry['file']}")
+    ninja = (build / "build.ninja").read_text()
+    if re.search(r"libQt6\w+_debug\.a", ninja):
+        raise ValueError("Release build links Debug Qt")
+    print(f"Release {';'.join(sorted(expected))}: checked {len(product)} compilation commands")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build", type=Path)
+    parser.add_argument("--architectures", nargs="+", choices=("arm64", "x86_64"), default=["arm64"])
+    parser.add_argument("--disable-autoupdate", action="store_true")
+    args = parser.parse_args()
+    check(args.build, args.architectures, args.disable_autoupdate)

--- a/Telegram/build/prepare/macos_options.py
+++ b/Telegram/build/prepare/macos_options.py
@@ -1,0 +1,12 @@
+def qt_options(options):
+    architectures = [name for name in ("arm64", "x86_64") if "mac-" + name in options]
+    if len(architectures) > 1:
+        raise ValueError("Choose one macOS architecture, or omit both for universal.")
+    if "qt-release-only" in options and "skip-release" in options:
+        raise ValueError("qt-release-only conflicts with skip-release.")
+    configuration = (
+        "-debug" if "skip-release" in options else
+        "-release" if "qt-release-only" in options else
+        "-debug-and-release"
+    )
+    return configuration, ";".join(architectures or ["x86_64", "arm64"])

--- a/Telegram/build/prepare/prepare.py
+++ b/Telegram/build/prepare/prepare.py
@@ -5,6 +5,7 @@ sys.dont_write_bytecode = True
 scriptPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(scriptPath + '/..')
 import qt_version
+from macos_options import qt_options
 
 def finish(code):
     global executePath
@@ -61,6 +62,9 @@ optionsList = [
     'qt6',
     'skip-release',
     'build-stackwalk',
+    'qt-release-only',
+    'mac-arm64',
+    'mac-x86_64',
 ]
 options = []
 runCommand = []
@@ -75,6 +79,13 @@ for arg in sys.argv[1:]:
     elif arg == 'shell':
         customRunCommand = True
         runCommand.append('shell')
+
+try:
+    macQtConfiguration, macQtArchitectures = qt_options(options)
+except ValueError as exception:
+    error(str(exception))
+if not mac and any(option in options for option in ('qt-release-only', 'mac-arm64', 'mac-x86_64')):
+    error('macOS preparation options require macOS.')
 
 if not os.path.isdir(os.path.join(libsDir, keysLoc)):
     pathlib.Path(os.path.join(libsDir, keysLoc)).mkdir(parents=True, exist_ok=True)
@@ -1598,9 +1609,7 @@ mac:
     find $PWD/../patches/qtbase_$QT -type f -print0 | sort -z | xargs -0 git -C qtbase apply -v
     sed -i.bak 's/tqtc-//' {qtimageformats,qtsvg}/dependencies.yaml
 
-    CONFIGURATIONS=-debug
-release:
-    CONFIGURATIONS=-debug-and-release
+    CONFIGURATIONS=""" + macQtConfiguration + """
 mac:
     ./configure -prefix "$USED_PREFIX/Qt-$QT" \
         $CONFIGURATIONS \
@@ -1618,7 +1627,7 @@ mac:
         -no-feature-brotli \
         -no-feature-cxx17_filesystem \
         -platform macx-clang -- \
-        -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+        -DCMAKE_OSX_ARCHITECTURES=\"""" + macQtArchitectures + """\" \
         -DCMAKE_PREFIX_PATH="$USED_PREFIX" \
         -DQT_NO_HANDLE_APPLE_SINGLE_ARCH_CROSS_COMPILING=ON \
         -DQT_SYNC_HEADERS_AT_CONFIGURE_TIME=ON

--- a/Telegram/build/test_check_macos_release.py
+++ b/Telegram/build/test_check_macos_release.py
@@ -1,0 +1,98 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_macos_release import check
+
+
+class ReleaseCheckTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.build = Path(self.directory.name)
+        (self.build / "CMakeCache.txt").write_text(
+            "CMAKE_BUILD_TYPE:STRING=Release\n"
+            "CMAKE_OSX_ARCHITECTURES:STRING=arm64\n"
+            "DESKTOP_APP_DISABLE_AUTOUPDATE:BOOL=ON\n"
+        )
+        (self.build / "build.ninja").write_text("libQt6Widgets.a")
+        self.command = {
+            "file": "/src/Telegram/SourceFiles/core/application.cpp",
+            "command": "clang++ -O3 -DNDEBUG -arch arm64 -c application.cpp",
+        }
+
+    def run_check(self, architectures=("arm64",), disable_autoupdate=False):
+        (self.build / "compile_commands.json").write_text(json.dumps([self.command]))
+        check(self.build, architectures, disable_autoupdate)
+
+    def test_release(self):
+        self.run_check()
+
+    def test_debug_optimization_rejected(self):
+        self.command["command"] += " -O0"
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_debug_defines_rejected(self):
+        self.command["command"] += " -D_DEBUG"
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_intel_rejected(self):
+        self.command["command"] = self.command["command"].replace("arm64", "x86_64")
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_debug_qt_rejected(self):
+        (self.build / "build.ninja").write_text("libQt6Widgets_debug.a")
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_wrong_build_type_rejected(self):
+        path = self.build / "CMakeCache.txt"
+        path.write_text(path.read_text().replace("=Release", "=Debug"))
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_each_target(self):
+        for architectures in (("x86_64",), ("x86_64", "arm64")):
+            with self.subTest(architectures=architectures):
+                (self.build / "CMakeCache.txt").write_text(
+                    "CMAKE_BUILD_TYPE:STRING=Release\n"
+                    "CMAKE_OSX_ARCHITECTURES:STRING=" + ";".join(architectures) + "\n"
+                )
+                self.command["command"] = "clang++ -O3 -DNDEBUG " + " ".join("-arch " + arch for arch in architectures)
+                self.run_check(architectures)
+
+    def test_extra_architecture_rejected(self):
+        self.command["command"] += " -arch x86_64"
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_debug_define_with_value_rejected(self):
+        self.command["command"] += " -D_DEBUG=1"
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_undefined_ndebug_rejected(self):
+        self.command["command"] += " -UNDEBUG"
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+    def test_preview_requires_disabled_updater(self):
+        path = self.build / "CMakeCache.txt"
+        path.write_text(path.read_text().replace("=ON", "=OFF"))
+        self.run_check()
+        with self.assertRaises(ValueError):
+            self.run_check(disable_autoupdate=True)
+
+    def test_cache_value_must_match_exactly(self):
+        path = self.build / "CMakeCache.txt"
+        path.write_text(path.read_text().replace("=Release", "=ReleaseDebug"))
+        with self.assertRaises(ValueError):
+            self.run_check()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Telegram/build/test_macos_options.py
+++ b/Telegram/build/test_macos_options.py
@@ -1,0 +1,27 @@
+import unittest
+
+from prepare.macos_options import qt_options
+
+
+class MacOptionsTest(unittest.TestCase):
+    def test_default_preserves_debug_release_and_intel(self):
+        self.assertEqual(qt_options([]), ("-debug-and-release", "x86_64;arm64"))
+
+    def test_release_only(self):
+        self.assertEqual(qt_options(["qt-release-only"]), ("-release", "x86_64;arm64"))
+
+    def test_debug_only(self):
+        self.assertEqual(qt_options(["skip-release"]), ("-debug", "x86_64;arm64"))
+
+    def test_each_architecture(self):
+        for arch in ("arm64", "x86_64"):
+            with self.subTest(arch=arch):
+                self.assertEqual(qt_options(["mac-" + arch, "qt-release-only"]), ("-release", arch))
+
+    def test_conflicting_architectures(self):
+        with self.assertRaises(ValueError):
+            qt_options(["mac-arm64", "mac-x86_64"])
+
+    def test_conflicting_configurations(self):
+        with self.assertRaises(ValueError):
+            qt_options(["qt-release-only", "skip-release"])

--- a/docs/building-mac.md
+++ b/docs/building-mac.md
@@ -1,29 +1,71 @@
-## Build instructions for macOS
+# Build instructions for macOS
 
-### Prepare folder
+Use a recursive checkout of the repository and branch you intend to build.
+Its parent directory holds `Libraries` and `ThirdParty`; keep application
+profiles outside those build directories. Allow at least 55 GB for a cold
+universal build.
 
-Choose a folder for the future build, for example **/Users/user/TBuild**. It will be named ***BuildPath*** in the rest of this document. All commands will be launched from Terminal.
+Install Xcode and Homebrew first. CI uses Xcode 16.4 on `macos-15`; the `.icns`
+fallback does not require Xcode 26's Icon Composer.
 
-**Note about disk space:** The full build process will require approximately **55 GB** of free space. This includes:
-- **~35 GB** for libraries (when building for both x64 and arm64 architectures)
-- **~20 GB** for the compiled Telegram app (in the `out` folder)
+```bash
+brew install git automake libtool cmake pkg-config ninja nasm meson ccache
+```
 
-### Clone source code and prepare libraries
+Select the installed Xcode using `xcode-select` if necessary. Obtain your own
+`TDESKTOP_API_ID` and `TDESKTOP_API_HASH` as described in
+[Telegram's application registration instructions](https://core.telegram.org/api/obtaining_api_id)
+and export them in the build shell. Do not commit credentials.
 
-Go to ***BuildPath*** and run
+## Release preview
 
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    brew install git automake libtool cmake wget pkg-config gnu-tar ninja nasm meson
+From the checkout root, build a universal package:
 
-    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```bash
+./Telegram/build/prepare/mac.sh silent qt-release-only
+cd Telegram
+./configure.sh -G Ninja \
+  -D CMAKE_BUILD_TYPE=Release \
+  -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -D 'CMAKE_OSX_ARCHITECTURES=x86_64;arm64' \
+  -D DESKTOP_APP_MAC_ARCH= \
+  -D CMAKE_C_COMPILER_LAUNCHER=ccache \
+  -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -D "TDESKTOP_API_ID=$TDESKTOP_API_ID" \
+  -D "TDESKTOP_API_HASH=$TDESKTOP_API_HASH" \
+  -D DESKTOP_APP_DISABLE_AUTOUPDATE=ON
+python3 build/check_macos_release.py ../out \
+  --architectures x86_64 arm64 --disable-autoupdate
+cmake --build ../out --parallel 3 --target Telegram
+```
 
-    git clone --recursive https://github.com/AyuGram/AyuGramDesktop.git tdesktop
-    ./tdesktop/Telegram/build/prepare/mac.sh
+The result is `out/AyuGram.app`. CI packages use ad-hoc signing for testing,
+not a Developer ID signature or Apple notarization. Public distribution needs
+maintainer-controlled signing, notarization and a verified update channel.
 
-### Building the project
+For Apple Silicon only, append `mac-arm64` to the preparation command and set
+both `CMAKE_OSX_ARCHITECTURES` and `DESKTOP_APP_MAC_ARCH` to `arm64`. Pass only
+`arm64` to the checker. For Intel only, use `mac-x86_64` and `x86_64` instead.
+Other dependencies retain their upstream universal build recipes.
 
-Go to ***BuildPath*/tdesktop/Telegram** and run
+## Debug and Xcode development
 
-    ./configure.sh -D TDESKTOP_API_ID=2040 -D TDESKTOP_API_HASH=b18441a1ff607e10a989891a5462e627
+Without `qt-release-only`, preparation retains the upstream defaults: universal
+Qt with Debug and Release configurations. `skip-release` builds Debug Qt only;
+it cannot be combined with `qt-release-only`. Do not reuse a Release-only Qt
+installation for a Debug application without rerunning preparation.
 
-Then launch Xcode, open ***BuildPath*/tdesktop/out/Telegram.xcodeproj** and build for Debug / Release.
+Omit `-G Ninja` to use Xcode. Open `out/Telegram.xcodeproj` and choose the
+configuration there. Use Release for daily use and distribution.
+
+## CI and updates
+
+The `AyuGram macOS` workflow accepts the target architecture on manual dispatch.
+It checks the generated compiler commands, Qt linkage, bundle identity, icon
+and packaged architectures, then produces a ZIP with checksum and source SHA.
+Credentials come from repository configuration, not from a particular owner
+or branch name. The full build is not triggered on every push.
+
+Automatic updates remain disabled for these preview packages until the
+distribution has a verified signing and update channel. This does not change
+the source default for maintainers building official releases.


### PR DESCRIPTION
This PR was prepared with AI assistance.

## Problem
macOS builds need a reproducible Release path that does not accidentally use Debug Qt or compiler flags. Icon Composer resources also need a fallback with older Xcode and Ninja.

Related work: #427. This PR provides a separate, portable Release-preview workflow; it does not claim authorship of that earlier proposal.

## Changes
- Manual CI builds for universal (default), arm64 or x86_64, using Ninja, Release-only Qt, dependency/ccache caches and bounded parallel compilation.
- Preserve the existing universal Debug+Release preparation default. Add explicit, validated single-architecture and Release-only options.
- Fail early when repository API credentials are missing; no personal credentials or owner/branch assumptions.
- Validate Release compiler flags, Qt linkage, architecture, bundle ID, icon resources and ad-hoc signature before producing a ZIP, checksum and source SHA.
- Use Icon Composer only with Xcode 26+, fix the fallback icon resource name and the plist icon name.
- Add lightweight source checks and update the macOS build instructions.

Preview auto-updates are disabled. Ad-hoc signing is not Developer ID signing or notarization; these artifacts are not presented as a public production release.

## Verification
- 18 build-configuration unit tests passed.
- The actual Qt preparation stage was generated and shell-checked for default, Debug-only, universal Release-only, arm64 Release-only and x86_64 Release-only.
- `actionlint v1.7.12`, shell syntax for both workflows, Python syntax, `plutil -lint` and `git diff --check` passed.
- The approach has since carried a production run. A descendant of this workflow built and packaged universal macOS and Windows x64 as the technical build [AyuGram 7.2.9](https://github.com/oviron/AyuGramDesktop/releases/tag/v7.2.9) in [run 35279882815](https://github.com/oviron/AyuGramDesktop/actions/runs/35279882815); the published application reports both architectures and a valid deep signature.
- Four of the eleven files at this head are byte-identical in that build's commit `54c497cf53`: `.github/workflows/checks.yml`, `Telegram/Telegram.plist`, `Telegram/build/prepare/macos_options.py` and `Telegram/build/test_macos_options.py`. The rest evolved there, and `mac.yml` was folded into a single release workflow, so that run is **not** an exact-head build of this PR.
- The universal and Intel configurations at this exact head still need full builds.

This targets current `dev` independently of #468 and does not change the Telegram base version.

